### PR TITLE
Check for nil pointer reference on response object.

### DIFF
--- a/hub3/index/indexer.go
+++ b/hub3/index/indexer.go
@@ -78,8 +78,8 @@ func beforeFn(executionID int64, requests []BulkableRequest) {
 }
 
 func afterFn(executionID int64, requests []elastic.BulkableRequest, response *elastic.BulkResponse, err error) {
-	if response.Errors {
-		log.Println("Errors in bulk request")
+	if response != nil && response.Errors {
+		log.Println("Errors in response")
 		for _, item := range response.Failed() {
 			log.Printf("errored item: %#v errors: %#v", item, item.Error)
 		}


### PR DESCRIPTION
Ha Delving bro. Ik zag in de HUB3 log de onderstaande nil pointer panic voorbij komen. 
```log
Dec 27 10:42:50 svr0155 rapid: ELASTIC 2019/12/27 10:42:50 elastic: bulk processor "Hub3-backgroundworker" failed: Post http://ACPT-OMGEVING:9200/_bulk: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Dec 27 10:42:50 svr0155 rapid: panic: runtime error: invalid memory address or nil pointer dereference
Dec 27 10:42:50 svr0155 rapid: [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xadc8c9]
Dec 27 10:42:50 svr0155 rapid: goroutine 74 [running]:
Dec 27 10:42:50 svr0155 rapid: github.com/delving/hub3/hub3/index.afterFn(0xf77, 0xc00c330a80, 0x57a, 0x6a8, 0x0, 0x12ecf20, 0xc00bab1b30)
Dec 27 10:42:50 svr0155 rapid: /builds/zoeken-vinden-tonen/zvt-hub3/vendor/github.com/delving/hub3/hub3/index/indexer.go:81 +0x29
Dec 27 10:42:50 svr0155 rapid: github.com/olivere/elastic/v7.(*bulkWorker).commit(0xc000310fc0, 0x13032e0, 0xc000032048, 0x12f, 0xc00084bf48)
Dec 27 10:42:50 svr0155 rapid: /builds/zoeken-vinden-tonen/zvt-hub3/vendor/github.com/olivere/elastic/v7/bulk_processor.go:588 +0x2a0
Dec 27 10:42:50 svr0155 rapid: github.com/olivere/elastic/v7.(*bulkWorker).work(0xc000310fc0, 0x13032e0, 0xc000032048)
Dec 27 10:42:50 svr0155 rapid: /builds/zoeken-vinden-tonen/zvt-hub3/vendor/github.com/olivere/elastic/v7/bulk_processor.go:487 +0x602
Dec 27 10:42:50 svr0155 rapid: created by github.com/olivere/elastic/v7.(*BulkProcessor).Start
Dec 27 10:42:50 svr0155 rapid: /builds/zoeken-vinden-tonen/zvt-hub3/vendor/github.com/olivere/elastic/v7/bulk_processor.go:336 +0x1af

```

Met deze pull request zou het niet meer moeten voor komen.