### PR TITLE
Grab node ids from alternate unitid types.

### DIFF
--- a/hub3/ead/ead.go
+++ b/hub3/ead/ead.go
@@ -298,20 +298,20 @@ func (ui *Cunitid) NewNodeID() (*NodeID, error) {
 
 // NewNodeIDs extract Unit Identifiers from the EAD did
 func (cdid *Cdid) NewNodeIDs() ([]*NodeID, string, error) {
-	ids := []*NodeID{}
-	var invertoryNumber string
+	var ids []*NodeID
+	var inventoryID string
 	for _, unitid := range cdid.Cunitid {
 		id, err := unitid.NewNodeID()
 		if err != nil {
 			return nil, "", err
 		}
 		switch id.Type {
-		case "ABS", "series_code", "":
-			invertoryNumber = id.ID
+		case "ABS", "series_code", "blank", "analoog", "BD", "":
+			inventoryID = id.ID
 		}
 		ids = append(ids, id)
 	}
-	return ids, invertoryNumber, nil
+	return ids, inventoryID, nil
 }
 
 // NewNodeDate extract date infomation frme the EAD unitdate
@@ -400,7 +400,7 @@ func (cdid *Cdid) NewHeader() (*Header, error) {
 
 func (n *Node) getPathID() string {
 	eadID := n.Header.InventoryNumber
-	if eadID == "" {
+	if eadID == "" || strings.HasPrefix(eadID, "---") {
 		eadID = strconv.FormatUint(n.Order, 10)
 	}
 	return fmt.Sprintf("%s", eadID)

--- a/hub3/ead/ead.go
+++ b/hub3/ead/ead.go
@@ -382,6 +382,13 @@ func (cdid *Cdid) NewHeader() (*Header, error) {
 		header.Date = append(header.Date, nodeDate)
 	}
 
+	for _, unitID := range cdid.Cunitid {
+		// Mark the header as Born Digital when we find a BD type unitid.
+		if strings.ToLower(unitID.Attrtype) == "bd" {
+			header.AltRender = "Born Digital"
+		}
+	}
+
 	nodeIDs, inventoryID, err := cdid.NewNodeIDs()
 	if err != nil {
 		return nil, err

--- a/hub3/ead/ead_test.go
+++ b/hub3/ead/ead_test.go
@@ -261,6 +261,61 @@ var _ = Describe("Ead", func() {
 				})
 			})
 
+			Context("when extracting nodeIDs from various types", func () {
+				var createUnitIDs = func (id string, nodeType string) []*Cunitid {
+					var cus []*Cunitid
+					cu := &Cunitid{
+						ID: id,
+						Attrtype: nodeType,
+					}
+					cus = append(cus, cu)
+					return cus
+				}
+				tests := []struct {
+					name   string
+					cdid    Cdid
+					wantID string
+				}{
+					{
+						"Should extract series_code type unit id",
+						Cdid{Cunitid: createUnitIDs("100", "series_code")},
+						"100",
+					},
+					{
+						"Should not extract unknown type",
+						Cdid{Cunitid: createUnitIDs("69", "unknown_type")},
+						"",
+					},
+					{
+						"Should extract dashes from blank types",
+						Cdid{Cunitid: createUnitIDs("---", "blank")},
+						"---",
+					},
+					{
+						"Should extract analoog",
+						Cdid{Cunitid: createUnitIDs("10000", "analoog")},
+						"10000",
+					},
+					{
+						"Should extract Born Digital type",
+						Cdid{Cunitid: createUnitIDs("DC-2015/446", "BD")},
+						"DC-2015/446",
+					},
+					{
+						"Should extract from empty type even when silly",
+						Cdid{Cunitid: createUnitIDs("miauw", "")},
+						"miauw",
+					},
+				}
+				for _, tt := range tests {
+					tt := tt
+					It(tt.name, func () {
+						_, inventoryID, _ := tt.cdid.NewNodeIDs()
+						Expect(inventoryID).To(Equal(tt.wantID))
+					})
+				}
+			})
+
 		})
 
 	})


### PR DESCRIPTION
The born digital EAD documents contain different Cunitid types that also have a unit id that need to be stored and displayed. We also need to display the blank type unit ids with the dashes "---" 