### PR TITLE
Fix incorrect reference to error causing a nil pointer panic.

### DIFF
--- a/hub3/server/http/handlers/ead.go
+++ b/hub3/server/http/handlers/ead.go
@@ -208,7 +208,7 @@ func TreeDescriptionAPI(w http.ResponseWriter, r *http.Request) {
 
 		hits, searchErr := descIndex.SearchWithString(query)
 		if searchErr != nil && !errors.Is(searchErr, memory.ErrSearchNoMatch) {
-			http.Error(w, getErr.Error(), http.StatusInternalServerError)
+			http.Error(w, searchErr.Error(), http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
Stack trace below

```
GET /api/ead/2.13.39/desc?eadid=2.13.39&search-type=item_code&query=%403~3.1~67,%2B474-534~503&filter=false&end=1&page=1
Runtime error: runtime error: invalid memory address or nil pointer dereference
Runtime Stack
goroutine 65486 [running]:
github.com/urfave/negroni.(*Recovery).ServeHTTP.func1(0x7f25aefc0550, 0xc024ce0b00, 0xc0000a6640, 0xc02d9e7100)
	/builds/zoeken-vinden-tonen/zvt-hub3/vendor/github.com/urfave/negroni/recovery.go:159 +0xcb
panic(0xf247c0, 0x1a4f890)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/delving/hub3/hub3/server/http/handlers.TreeDescriptionAPI(0x7f25aefc0600, 0xc02e1c5b00, 0xc02d9e7400)
	/builds/zoeken-vinden-tonen/zvt-hub3/vendor/github.com/delving/hub3/hub3/server/http/handlers/ead.go:211 +0xac5
net/http.HandlerFunc.ServeHTTP(0x11eba10, 0x7f25aefc0600, 0xc02e1c5b00, 0xc02d9e7400)
	/usr/local/go/src/net/http/server.go:2007 +0x44
```