### PR TITLE
scrollID calculation when searching and scrolling through the tree

### DIFF
--- a/hub3/fragments/api.go
+++ b/hub3/fragments/api.go
@@ -270,10 +270,12 @@ func NewSearchRequest(params url.Values) (*SearchRequest, error) {
 			sr.Tree = tree
 			tree.IsSearch = true
 			tree.Label = params.Get(p)
+			sr.ResponseSize = 1
 		case "byQuery":
 			sr.Tree = tree
 			tree.IsSearch = true
 			tree.Query = params.Get(p)
+			sr.ResponseSize = 1
 		case "withFields":
 			sr.Tree = tree
 			tree.WithFields = strings.EqualFold(params.Get(p), "true")


### PR DESCRIPTION
Set ResponseSize to 1 to properly calculate the scrollID and next cursor position when searching through the tree.