### PR TITLE
Allow deeplink into TreeList search results with start and searchAfter params

### DIFF
--- a/hub3/fragments/api.go
+++ b/hub3/fragments/api.go
@@ -345,7 +345,7 @@ func NewSearchRequest(params url.Values) (*SearchRequest, error) {
 			sr.Start = int32(start)
 		case "searchAfter":
 			var sa = make([]interface{}, 0)
-			parts := strings.Split(params.Get(p), ",")
+			parts := strings.SplitN(params.Get(p), ",", 2)
 			sortKey, _ := strconv.Atoi(parts[0])
 			cLevel := parts[1]
 			sa = append(sa, sortKey, cLevel)

--- a/hub3/fragments/api.go
+++ b/hub3/fragments/api.go
@@ -336,6 +336,25 @@ func NewSearchRequest(params url.Values) (*SearchRequest, error) {
 			}
 
 			tree.PageSize = int32(hint)
+		case "start":
+			start, err := strconv.Atoi(params.Get(p))
+			if err != nil {
+				log.Printf("unable to convert %v to int for %s", v, p)
+				return sr, err
+			}
+			sr.Start = int32(start)
+		case "searchAfter":
+			var sa = make([]interface{}, 0)
+			parts := strings.Split(params.Get(p), ",")
+			sortKey, _ := strconv.Atoi(parts[0])
+			cLevel := parts[1]
+			sa = append(sa, sortKey, cLevel)
+			sb, err := getInterfaceBytes(sa)
+			if err != nil {
+				log.Printf("unable to create bytes from interface %v", sa)
+				return sr, err
+			}
+			sr.SearchAfter = sb
 		}
 	}
 
@@ -956,6 +975,16 @@ func getInterface(bts []byte, data interface{}) error {
 	return err
 }
 
+func getInterfaceBytes(key interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	err := enc.Encode(key)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 // SearchRequestToHex converts the SearchRequest to a hex string
 func (sr *SearchRequest) SearchRequestToHex() (string, error) {
 	output, err := proto.Marshal(sr)
@@ -981,13 +1010,7 @@ func (sr *SearchRequest) DeepCopy() (*SearchRequest, error) {
 }
 
 func (sr *SearchRequest) CreateBinKey(key interface{}) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := gob.NewEncoder(&buf)
-	err := enc.Encode(key)
-	if err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return getInterfaceBytes(key)
 }
 
 // DecodeSearchAfter returns an interface array decoded from []byte


### PR DESCRIPTION
Please consider the following. We currently use the hex encoded scrollID to get the next resultset but there is a new case where we do not have this complete scrollID but we do have the searchAfter and start values. We want to jump into searchit N of a resultset. By exposing the start and searchAfter we can jump straight into the resultset with the correct cursor.

Usecase:

GET /api/ead/search/4.VEL?q=berg
_new_ partial response (in other GIT repo currently) of the performDetailSearch
```json
 "cLevels": [
    {
      "path": "@B~B.2~B.2.2~334~174",
      "unitID": "174",
      "label": "Kaart van de Saldanhabay met de Eilanden, klippen, banken, reven daarin gelegen, benevens aanwyzing der diepten, ankerplaatsen enz.",
      "hubID": "NL-HaNA_4.VEL_B~B.2~B.2.2~334~174",
      "sortKey": 338,
      "searchAfter": "338,@B~B.2~B.2.2~334~174",
      "start": 0
    },
    {
      "path": "@B~B.5~B.5.2~906~916~976~977~594.1-594.8",
      "unitID": "594.1-594.8",
      "label": "Plan der Zuydzyde der strekking van het Eyland Curaçao, van den berg van Altena tot het Oostpunt inclusive, met alle desselvs baayen en batteryen.",
      "hubID": "NL-HaNA_4.VEL_B~B.5~B.5.2~906~916~976~977~594.1-594.8",
      "sortKey": 998,
      "searchAfter": "998,@B~B.5~B.5.2~906~916~976~977~594.1-594.8",
      "start": 1
    }
]
```

With that info we can construct this API call
`/api/tree/4.VEL?withFields=true&byQuery=berg&paging=true&start=1&searchAfter=998,@B~B.5~B.5.2~906~916~976~977~594.1-594.8`

Which will jump straight into the search results on cursor position 1. The above call is equivalent to `/api/tree/4.VEL?qs=1801200132121a096d6574612e737065632205342e56454cba014d0cff81020102ff8200011000003fff82000207666c6f61743634080500fd20754006737472696e670c2300214e4c2d48614e415f342e56454c5f427e422e327e422e322e327e3333347e313734c00105fa01184a05342e56454c8001fa01980101aa010462657267b001018a021b3161755a593653766f4337774149337839717a304863526e4e6650`