### PR TITLE
Allow treePage calls with search hits.

### DIFF
--- a/hub3/fragments/api.go
+++ b/hub3/fragments/api.go
@@ -1075,6 +1075,7 @@ func (sr *SearchRequest) ElasticSearchService(ec *elastic.Client) (*elastic.Sear
 		Preference(sr.GetSessionID()).
 		Size(int(sr.GetResponseSize()))
 
+	// This section is used to return the tree page section of 250 nodes starting the current.
 	if sr.Tree != nil && sr.Tree.IsPaging && !sr.Tree.IsSearch {
 		s = s.SortBy(fieldSort)
 		_, current, _ := sr.Tree.PreviousCurrentNextPage()
@@ -1084,6 +1085,7 @@ func (sr *SearchRequest) ElasticSearchService(ec *elastic.Client) (*elastic.Sear
 			s = s.SearchAfter(searchAfterCursor)
 		}
 	} else {
+		// This section is used to get the search hit with size 1.
 		s = s.SortBy(fieldSort, idSort)
 		if len(sr.SearchAfter) != 0 && sr.CollapseOn == "" {
 			sa, err := sr.DecodeSearchAfter()


### PR DESCRIPTION
Please consider the following issue. When using the paging tree calls with `/api/tree/2.13.110?page=6&pageMode=append&paging=true&withFields=true&fillTree=true` we get page 6 in append mode to add new nodes to the tree in the treePage response key. But when using the paging tree call with a byQuery parameter to highlight searchTerms in the response we get the incorrect page back. In the current state we get back page 1 instead of page 6 because page 1 holds the first search result. The treePage in the response is also missing. `/api/tree/2.13.110?page=6&pageMode=append&paging=true&withFields=true&fillTree=true&byQuery=de` 
