### PR TITLE
Delete Dataset even if not all index types are configured.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixes
 
-- Delete DataSet does not work when when no v1 index is created [[GH-25]](https://github.com/delving/hub3/pull/24)
+- Delete DataSet does not work when when no v1 index is created [[GH-25]](https://github.com/delving/hub3/pull/25)
 
 ## v0.1.10 (2020-07-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - history of changes: see https://github.com/delving/hub3/compare/v0.1.10...master
 
+### Fixes
+
+- Delete DataSet does not work when when no v1 index is created [[GH-25]](https://github.com/delving/hub3/pull/24)
+
 ## v0.1.10 (2020-07-20)
 
 - history of changes: see https://github.com/delving/hub3/compare/v0.1.9...v0.1.10

--- a/hub3/models/dataset.go
+++ b/hub3/models/dataset.go
@@ -612,13 +612,18 @@ func (ds DataSet) deleteAllIndexRecords(ctx context.Context, wp *wp.WorkerPool) 
 		elastic.NewTermQuery("spec.raw", ds.Spec),
 	)
 
-	log.Warn().Msgf("%#v", q)
+	indices := []string{}
+	for _, indexType := range c.Config.ElasticSearch.IndexTypes {
+		switch indexType {
+		case "v1":
+			indices = append(indices, c.Config.ElasticSearch.GetV1IndexName())
+		case "v2":
+			indices = append(indices, c.Config.ElasticSearch.GetIndexName())
+		}
+	}
+
 	res, err := index.ESClient().DeleteByQuery().
-		Index(
-			c.Config.ElasticSearch.GetIndexName(),
-			c.Config.ElasticSearch.GetV1IndexName(),
-			c.Config.ElasticSearch.FragmentIndexName(),
-		).
+		Index(indices...).
 		Query(q).
 		Do(ctx)
 	if err != nil {


### PR DESCRIPTION
This fixes the issue that when v1 indexType is not defined in the configuration, that the dataset
cannot be deleted because the index cannot be found by ElasticSearch.