### PR TITLE
Allow for custom proxy routes to be added via options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - history of changes: see https://github.com/delving/hub3/compare/v0.1.10...master
 
+### Added
+
+- Allow for custom []ProxyRoute to be configured when configuring a DataNode proxy [[GH-26]](https://github.com/delving/hub3/pull/26)
+
 ### Fixes
 
 - Delete DataSet does not work when when no v1 index is created [[GH-25]](https://github.com/delving/hub3/pull/25)


### PR DESCRIPTION
Currently, only the default proxy routes are redirected to the DataNode.
For custom wrappers of ikuzo/hub3 server it should be possible to add
custom routes via the `ikuzo.SetDataNodeProxy`. These optional routes
take a ProxyRoute struct that configures a method and pattern to be
injected.