### PR TITLE
Added support for test-containers for unit tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - history of changes: see https://github.com/delving/hub3/compare/v0.1.11...master
 
+### Added 
+
+- Support for [test-containers](https://golang.testcontainers.org/) for ikuzo service and storage tests [[GH-27]](https://github.com/delving/hub3/pull/27)
+
 ## v0.1.11 (2020-07-21)
 
 - history of changes: see https://github.com/delving/hub3/compare/v0.1.10...v0.1.11

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.7.0
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.6.1
 	github.com/testcontainers/testcontainers-go v0.3.1
 	github.com/tidwall/gjson v1.6.0
 	github.com/tidwall/pretty v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -864,6 +864,7 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/steveyen/gtreap v0.0.0-20150807155958-0abe01ef9be2/go.mod h1:mjqs7N0Q6m5HpR7QfXVBZXZWSqTjQLeTujjA/xUp2uw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
@@ -872,6 +873,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/goleveldb v0.0.0-20190203031304-2f17a3356c66/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
@@ -1277,6 +1280,8 @@ gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v0.0.0-20181223230014-1083505acf35 h1:zpdCK+REwbk+rqjJmHhiCN6iBIigrZ39glqSF0P3KF0=
 gotest.tools v0.0.0-20181223230014-1083505acf35/go.mod h1:R//lfYlUuTOTfblYI3lGoAAAebUdzjvbmQsuB7Ykd90=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=

--- a/ikuzo/service/x/index/option.go
+++ b/ikuzo/service/x/index/option.go
@@ -31,6 +31,7 @@ func SetNatsConfiguration(ncfg *NatsConfig) Option {
 	return func(s *Service) error {
 		s.stan = ncfg
 		s.stan.setDefaults()
+
 		return nil
 	}
 }

--- a/ikuzo/service/x/index/suite_test.go
+++ b/ikuzo/service/x/index/suite_test.go
@@ -1,0 +1,72 @@
+package index
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/matryer/is"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+type indexSuite struct {
+	suite.Suite
+	stanC testcontainers.Container
+	ip    string
+	port  nat.Port
+	ctx   context.Context
+}
+
+func TestIndexSuite(t *testing.T) {
+	suite.Run(t, new(indexSuite))
+}
+
+// nolint:gocritic
+func (s *indexSuite) SetupSuite() {
+	is := is.New(s.T())
+
+	req := testcontainers.ContainerRequest{
+		Image:        "nats-streaming:0.17.0",
+		ExposedPorts: []string{"4222"},
+		WaitingFor:   wait.ForLog("Streaming Server is ready"),
+		Cmd: []string{
+			"--cluster_id",
+			"hub3-nats",
+			"--http_port",
+			"8222",
+			"--port",
+			"4222",
+			"--max_bytes",
+			"1GB",
+			"--max_msgs",
+			"1000000",
+			// debugging information
+			// "-SV",
+			// "-SD",
+		},
+	}
+
+	s.ctx = context.Background()
+
+	var err error
+	s.stanC, err = testcontainers.GenericContainer(s.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	is.NoErr(err)
+
+	s.ip, err = s.stanC.Host(s.ctx)
+	is.NoErr(err)
+
+	s.port, err = s.stanC.MappedPort(s.ctx, "4222")
+	is.NoErr(err)
+}
+
+// nolint:gocritic
+func (s *indexSuite) TearDownSuite() {
+	is := is.New(s.T())
+	err := s.stanC.Terminate(s.ctx)
+	is.NoErr(err)
+}

--- a/ikuzo/storage/x/elasticsearch/alias_test.go
+++ b/ikuzo/storage/x/elasticsearch/alias_test.go
@@ -16,6 +16,7 @@ package elasticsearch
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -25,13 +26,15 @@ import (
 )
 
 // nolint:gocritic
-func TestAlias(t *testing.T) {
-	is := is.New(t)
+func (s *elasticSuite) TestAlias() {
+	is := is.New(s.T())
 
-	es, err := elasticsearch.NewDefaultClient()
+	cfg := elasticsearch.Config{Addresses: []string{fmt.Sprintf("http://%s:%s", s.ip, s.port.Port())}}
+	es, err := elasticsearch.NewClient(cfg)
 	is.NoErr(err)
 
 	res, err := es.Info()
+	s.T().Logf("elasticsearch status: %s", res.Status())
 	is.NoErr(err)
 	is.True(res.IsError() == false)
 

--- a/ikuzo/storage/x/elasticsearch/index_test.go
+++ b/ikuzo/storage/x/elasticsearch/index_test.go
@@ -16,9 +16,9 @@ package elasticsearch
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
-	"testing"
 
 	"github.com/delving/hub3/ikuzo/storage/x/elasticsearch/mapping"
 	"github.com/elastic/go-elasticsearch/v8"
@@ -26,10 +26,11 @@ import (
 )
 
 // nolint:gocritic
-func TestIndex(t *testing.T) {
-	is := is.New(t)
+func (s *elasticSuite) TestIndex() {
+	is := is.New(s.T())
 
-	es, err := elasticsearch.NewDefaultClient()
+	cfg := elasticsearch.Config{Addresses: []string{fmt.Sprintf("http://%s:%s", s.ip, s.port.Port())}}
+	es, err := elasticsearch.NewClient(cfg)
 	is.NoErr(err)
 
 	res, err := es.Info()

--- a/ikuzo/storage/x/elasticsearch/suite_test.go
+++ b/ikuzo/storage/x/elasticsearch/suite_test.go
@@ -1,0 +1,64 @@
+package elasticsearch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/matryer/is"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+type elasticSuite struct {
+	suite.Suite
+	elasticSearchC testcontainers.Container
+	ip             string
+	port           nat.Port
+	ctx            context.Context
+}
+
+func TestElasticSearchSuite(t *testing.T) {
+	suite.Run(t, new(elasticSuite))
+}
+
+// nolint:gocritic
+func (s *elasticSuite) SetupSuite() {
+	is := is.New(s.T())
+
+	req := testcontainers.ContainerRequest{
+		Image:        "docker.elastic.co/elasticsearch/elasticsearch:7.6.1",
+		ExposedPorts: []string{"9200"},
+		// WaitingFor:   wait.ForHTTP(":9200/"),
+		WaitingFor: wait.ForLog("indices into cluster_state"),
+		Env: map[string]string{
+			"discovery.type":         "single-node",
+			"cluster.name":           "ikuzo_cluster",
+			"xpack.security.enabled": "false",
+			"ES_JAVA_OPTS":           "-Xms1024m -Xmx1024m",
+		},
+	}
+
+	s.ctx = context.Background()
+
+	var err error
+	s.elasticSearchC, err = testcontainers.GenericContainer(s.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	is.NoErr(err)
+
+	s.ip, err = s.elasticSearchC.Host(s.ctx)
+	is.NoErr(err)
+
+	s.port, err = s.elasticSearchC.MappedPort(s.ctx, "9200")
+	is.NoErr(err)
+}
+
+// nolint:gocritic
+func (s *elasticSuite) TearDownSuite() {
+	is := is.New(s.T())
+	err := s.elasticSearchC.Terminate(s.ctx)
+	is.NoErr(err)
+}


### PR DESCRIPTION
In the ikuzo package for service and storage integration tests against
external backends should use test suites that spin up dedicated docker
containers per package. This will ensure that they can all run in
parallel without interference.