### PR TITLE
Use errgroup.Group to retrieve webresource urns in parallel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Code quality improvements reported by SonarCloud and golangci-lint [[GH-35]](https://github.com/delving/hub3/pull/35)
+- Concurrent retrieval of RDF for webresources now uses errgroup [[GH-44]](https://github.com/delving/hub3/pull/44)
 
 ### Removed
 

--- a/hub3/fragments/v1_test.go
+++ b/hub3/fragments/v1_test.go
@@ -16,6 +16,7 @@ package fragments_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -92,7 +93,7 @@ var _ = Describe("V1", func() {
 			It("should return a map", func() {
 				fb, err := testDataGraph(false)
 				Expect(err).ToNot(HaveOccurred())
-				_ = fb.GetSortedWebResources()
+				_ = fb.GetSortedWebResources(context.Background())
 				indexDoc, err := CreateV1IndexDoc(fb)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(indexDoc).ToNot(BeEmpty())
@@ -115,7 +116,7 @@ var _ = Describe("V1", func() {
 				fb, err := testDataGraph(false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(fb.Graph.Len()).ToNot(Equal(0))
-				wr := fb.GetSortedWebResources()
+				wr := fb.GetSortedWebResources(context.Background())
 				Expect(wr).ToNot(BeNil())
 				Expect(wr).To(HaveLen(3))
 				var order []int
@@ -164,7 +165,7 @@ var _ = Describe("V1", func() {
 			It("should have the ore:aggregation subject as subject for edm:hasView", func() {
 				fb, err := testDataGraph(false)
 				Expect(err).ToNot(HaveOccurred())
-				wr := fb.GetSortedWebResources()
+				wr := fb.GetSortedWebResources(context.Background())
 				Expect(wr).ToNot(BeEmpty())
 				triples := fb.SortedGraph.ByPredicate(GetEDMField("hasView"))
 				Expect(triples).ToNot(BeNil())
@@ -195,7 +196,7 @@ var _ = Describe("V1", func() {
 				//Expect(err).ToNot(HaveOccurred())
 				//fmt.Println(json)
 
-				wr := fb.GetSortedWebResources()
+				wr := fb.GetSortedWebResources(context.Background())
 				Expect(wr).ToNot(BeEmpty())
 				//Expect(fb.Graph.Len()).To(Equal(70))
 
@@ -225,7 +226,7 @@ var _ = Describe("V1", func() {
 				fb, err := testDataGraph(false)
 				Expect(err).ToNot(HaveOccurred())
 				fb.Graph = g
-				fb.GetSortedWebResources()
+				fb.GetSortedWebResources(context.Background())
 				json, err = renderJSONLD(fb.Graph)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(json).ToNot(BeEmpty())

--- a/ikuzo/ikuzoctl/cmd/index.go
+++ b/ikuzo/ikuzoctl/cmd/index.go
@@ -167,7 +167,7 @@ func indexRecords() error {
 			return ctx.Err()
 		}
 
-		if err := parser.Publish(v1rec.bulkRequest()); err != nil {
+		if err := parser.Publish(ctx, v1rec.bulkRequest()); err != nil {
 			log.Error().Err(err).Msgf("bulk request: %#v", v1rec.bulkRequest())
 			return err
 		}

--- a/ikuzo/service/x/bulk/parser.go
+++ b/ikuzo/service/x/bulk/parser.go
@@ -159,7 +159,7 @@ func (p *Parser) process(ctx context.Context, req *Request) error {
 
 	switch req.Action {
 	case "index":
-		return p.Publish(req)
+		return p.Publish(ctx, req)
 	case "increment_revision":
 		ds, err := p.ds.IncrementRevision()
 		if err != nil {
@@ -220,7 +220,7 @@ func (p *Parser) dropPosthook(orgID, datasetID string, revision int) {
 	}
 }
 
-func (p *Parser) Publish(req *Request) error {
+func (p *Parser) Publish(ctx context.Context, req *Request) error {
 	if err := req.valid(); err != nil {
 		return err
 	}
@@ -240,11 +240,11 @@ func (p *Parser) Publish(req *Request) error {
 	for _, indexType := range p.indexTypes {
 		switch indexType {
 		case "v1":
-			if err := req.processV1(fb, p.bi); err != nil {
+			if err := req.processV1(ctx, fb, p.bi); err != nil {
 				return err
 			}
 		case "v2":
-			if err := req.processV2(fb, p.bi); err != nil {
+			if err := req.processV2(ctx, fb, p.bi); err != nil {
 				return err
 			}
 		case "fragments":

--- a/ikuzo/service/x/bulk/request.go
+++ b/ikuzo/service/x/bulk/request.go
@@ -80,8 +80,8 @@ func (req *Request) createFragmentBuilder(revision int) (*fragments.FragmentBuil
 	return fb, nil
 }
 
-func (req *Request) processV1(fb *fragments.FragmentBuilder, bi index.BulkIndex) error {
-	fb.GetSortedWebResources()
+func (req *Request) processV1(ctx context.Context, fb *fragments.FragmentBuilder, bi index.BulkIndex) error {
+	fb.GetSortedWebResources(ctx)
 
 	indexDoc, err := fragments.CreateV1IndexDoc(fb)
 	if err != nil {
@@ -102,20 +102,20 @@ func (req *Request) processV1(fb *fragments.FragmentBuilder, bi index.BulkIndex)
 		Source:         b,
 	}
 
-	if err := bi.Publish(context.Background(), m); err != nil {
+	if err := bi.Publish(ctx, m); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (req *Request) processV2(fb *fragments.FragmentBuilder, bi index.BulkIndex) error {
+func (req *Request) processV2(ctx context.Context, fb *fragments.FragmentBuilder, bi index.BulkIndex) error {
 	m, err := fb.Doc().IndexMessage()
 	if err != nil {
 		return err
 	}
 
-	if err := bi.Publish(context.Background(), m); err != nil {
+	if err := bi.Publish(ctx, m); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Using errgroup.Group we create a Process, Map, Reduce pipeline to
retrieve the webresource urns for the v1 processing in parallel.

closes #43