### PR TITLE
Added configuration for max tree size for EAD tree API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Support for [test-containers](https://golang.testcontainers.org/) for ikuzo service and storage tests [[GH-27]](https://github.com/delving/hub3/pull/27)
 - GitHub Action configurations and quality control [[GH-29]](https://github.com/delving/hub3/pull/29)
+- Config option `maxTreeSize`for setting the maximum size of the navigation tree API [[GH-46]](https://github.com/delving/hub3/pull/48)
 
 ### Fixed
 

--- a/config/config.go
+++ b/config/config.go
@@ -91,7 +91,8 @@ type ElasticSearch struct {
 	RequestTimeout     int      `json:"requestTimeout"`
 	EnableSearchAfter  bool     `json:"enableSearchAfter"`
 	TrackTotalHits     bool     `json:"trackTotalHits"`
-	IndexTypes         []string
+	IndexTypes         []string `json:"indexTypes"`
+	MaxTreeSize        int      `json:"maxTreeSize"`
 }
 
 // FragmentIndexName returns the name of the Fragment index.
@@ -256,6 +257,7 @@ func setDefaults() {
 	viper.SetDefault("ElasticSearch.Shards", 1)
 	viper.SetDefault("ElasticSearch.Replicas", 0)
 	viper.SetDefault("ElasticSearch.RequestTimeout", 15)
+	viper.SetDefault("ElasticSearch.MaxTreeSize", 250)
 	viper.SetDefault("ElasticSearch.TrackTotalHits", true)
 	viper.SetDefault("ElasticSearch.IndexTypes", []string{"v2"})
 

--- a/hub3.toml
+++ b/hub3.toml
@@ -73,8 +73,8 @@ shards = 1
 replicas = 0
 # indexTypes enabled types for the bulk index service
 indexTypes = ["v1", "v2"]
-# maxTreeSize is the maximum size of the number of nodes in the tree API
-maxTreeSize = 250
+# maxTreeSize is the maximum size of the number of nodes in the tree navigation API
+maxTreeSize = 251
 
 [[posthooks]]
 name = "ginger"

--- a/hub3.toml
+++ b/hub3.toml
@@ -73,6 +73,8 @@ shards = 1
 replicas = 0
 # indexTypes enabled types for the bulk index service
 indexTypes = ["v1", "v2"]
+# maxTreeSize is the maximum size of the number of nodes in the tree API
+maxTreeSize = 250
 
 [[posthooks]]
 name = "ginger"

--- a/hub3/fragments/api.go
+++ b/hub3/fragments/api.go
@@ -1101,6 +1101,10 @@ func (sr *SearchRequest) ElasticSearchService(ec *elastic.Client) (*elastic.Sear
 		if sr.Tree.IsPaging {
 			sr.ResponseSize = sr.Tree.TreePagingSize()
 		}
+
+		if len(sr.Tree.Type) > 0 {
+			sr.ResponseSize = int32(c.Config.ElasticSearch.MaxTreeSize)
+		}
 	}
 
 	s := ec.Search().


### PR DESCRIPTION
Now you can support larger navigation trees than the default 250 nodes.