### PR TITLE
Override digital processing during ead upload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - GitHub Action configurations and quality control [[GH-29]](https://github.com/delving/hub3/pull/29)
 - Add logging when EAD dataset is deleted [[GH-46]](https://github.com/delving/hub3/pull/46)
 - Config option `maxTreeSize`for setting the maximum size of the navigation tree API [[GH-46]](https://github.com/delving/hub3/pull/48)
+- Config opion `processDigital` to enable processing of digital object links in EAD upload [[GH-48]](https://github.com/delving/hub3/pull/48)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - Support for [test-containers](https://golang.testcontainers.org/) for ikuzo service and storage tests [[GH-27]](https://github.com/delving/hub3/pull/27)
 - GitHub Action configurations and quality control [[GH-29]](https://github.com/delving/hub3/pull/29)
 - Add logging when EAD dataset is deleted [[GH-46]](https://github.com/delving/hub3/pull/46)
-- Config option `maxTreeSize`for setting the maximum size of the navigation tree API [[GH-46]](https://github.com/delving/hub3/pull/48)
-- Config opion `processDigital` to enable processing of digital object links in EAD upload [[GH-48]](https://github.com/delving/hub3/pull/48)
+- Config option `maxTreeSize`for setting the maximum size of the navigation tree API [[GH-48]](https://github.com/delving/hub3/pull/48)
+- Config opion `processDigital` to enable processing of digital object links in EAD upload [[GH-49]](https://github.com/delving/hub3/pull/49)
 
 ### Fixed
 

--- a/hub3.toml
+++ b/hub3.toml
@@ -202,6 +202,7 @@ singleEndpoint = "NL-.*"
 cacheDir = "/tmp/ead"
 metrics = true
 workers = 1
+processDigital = false
 
 searchURL = ""
 genreFormDefault = "other/unknown"

--- a/hub3/ead/nodes.go
+++ b/hub3/ead/nodes.go
@@ -186,38 +186,6 @@ func CreateTree(cfg *NodeConfig, n *Node, hubID string, id string) *fragments.Tr
 	tree.HasRestriction = n.AccessRestrict != ""
 	tree.PhysDesc = n.Header.Physdesc
 
-	if tree.HasDigitalObject && cfg.ProcessDigital {
-		if !strings.Contains(tree.DaoLink, "/gaf/api/mets/v1/") {
-			cfg.MetsCounter.AppendError(fmt.Sprintf("invalid daolink to GAF: %s", tree.DaoLink))
-			return tree
-		}
-
-		mets, err := remoteMETS(cfg.Client, tree.DaoLink, cfg.Spec, tree.UnitID)
-		// mets, err := localMETS(tree.DaoLink, cfg.Spec, tree.UnitID)
-		if err != nil {
-			cfg.MetsCounter.AppendError(err.Error())
-			return tree
-		}
-
-		findingAid, err := mets.newFindingAid(cfg, tree)
-
-		if err != nil {
-			cfg.MetsCounter.AppendError(err.Error())
-			return tree
-		}
-
-		tree.DOCount = int(findingAid.GetFileCount())
-		tree.MimeTypes = getMimeTypes(&findingAid)
-		cfg.MetsCounter.IncrementDigitalObject(uint64(tree.DOCount))
-
-		err = saveFileFragmentGraphs(cfg, &findingAid)
-		if err != nil {
-			// eventType := eventTypeFromRevision(int(cfg.Revision))
-			// logProcessEadError(cfg.Spec, eventType, "Unable to save fragment graphs for mets: %#v", err)
-			return tree
-		}
-	}
-
 	return tree
 }
 

--- a/ikuzo/ikuzoctl/cmd/config/ead.go
+++ b/ikuzo/ikuzoctl/cmd/config/ead.go
@@ -23,9 +23,10 @@ import (
 )
 
 type EAD struct {
-	CacheDir string `json:"cacheDir"`
-	Metrics  bool   `json:"metrics"`
-	Workers  int    `json:"workers"`
+	CacheDir       string `json:"cacheDir"`
+	Metrics        bool   `json:"metrics"`
+	Workers        int    `json:"workers"`
+	ProcessDigital bool   `json:"processDigital"`
 }
 
 func (e EAD) NewService(cfg *Config) (*ead.Service, error) {
@@ -38,6 +39,7 @@ func (e EAD) NewService(cfg *Config) (*ead.Service, error) {
 		ead.SetIndexService(is),
 		ead.SetDataDir(e.CacheDir),
 		ead.SetWorkers(e.Workers),
+		ead.SetProcessDigital(e.ProcessDigital),
 	)
 	if err != nil {
 		return nil, err

--- a/ikuzo/service/x/ead/meta.go
+++ b/ikuzo/service/x/ead/meta.go
@@ -33,6 +33,7 @@ type Meta struct {
 	DigitalObjects        uint64
 	FileSize              uint64
 	Revision              int32
+	ProcessDigital        bool
 	Created               bool
 	ProcessingDuration    time.Duration `json:"processingDuration,omitempty"`
 	ProcessingDurationFmt string        `json:"processingDurationFmt,omitempty"`

--- a/ikuzo/service/x/ead/options.go
+++ b/ikuzo/service/x/ead/options.go
@@ -41,9 +41,9 @@ func SetIndexService(is *index.Service) Option {
 	}
 }
 
-func SetProcessDigital(enabled bool) Option {
+func SetProcessDigital(isEnabled bool) Option {
 	return func(s *Service) error {
-		s.processDigital = enabled
+		s.processDigital = isEnabled
 		return nil
 	}
 }

--- a/ikuzo/service/x/ead/options.go
+++ b/ikuzo/service/x/ead/options.go
@@ -27,6 +27,13 @@ func SetDataDir(path string) Option {
 	}
 }
 
+func SetCreateTree(fn CreateTreeFn) Option {
+	return func(s *Service) error {
+		s.CreateTreeFn = fn
+		return nil
+	}
+}
+
 func SetIndexService(is *index.Service) Option {
 	return func(s *Service) error {
 		s.index = is
@@ -34,9 +41,9 @@ func SetIndexService(is *index.Service) Option {
 	}
 }
 
-func SetCreateTree(fn CreateTreeFn) Option {
+func SetProcessDigital(enabled bool) Option {
 	return func(s *Service) error {
-		s.CreateTreeFn = fn
+		s.processDigital = enabled
 		return nil
 	}
 }


### PR DESCRIPTION
Via the `mets` param you can override the processing parameter set in
the config `processDigital` during the EAD upload.

This functionality is added to benefit automated testing that does not
need the additional indexed digital object records from the METS files.