### PR TITLE
Fix for EAD highlighting in text with pseudo-html tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Code quality improvements reported by SonarCloud and golangci-lint [[GH-35]](https://github.com/delving/hub3/pull/35)
 - Concurrent retrieval of RDF for webresources now uses errgroup [[GH-44]](https://github.com/delving/hub3/pull/44)
 - Orphan Control is now excecuted when all domainpb.IndexMessage have been processed [[GH-47]](https://github.com/delving/hub3/pull/47)
+- Search highlighting now adds style-class to all hits when surrounded by custom tags [[GH-50]](https://github.com/delving/hub3/pull/47)
 
 ### Removed
 

--- a/ikuzo/service/x/search/tokenizer.go
+++ b/ikuzo/service/x/search/tokenizer.go
@@ -282,6 +282,10 @@ func (ts *TokenStream) Highlight(vectors *Vectors, tagLabel, emClass string) str
 			str.WriteString(" ")
 		}
 
+		if !ok && splitHightlight && !token.Ignored {
+			splitHightlight = false
+		}
+
 		if ok && !inHighlight {
 			inHighlight = true
 

--- a/ikuzo/service/x/search/tokenizer_test.go
+++ b/ikuzo/service/x/search/tokenizer_test.go
@@ -305,6 +305,7 @@ func TestParseError(t *testing.T) {
 	is.Equal(len(tok.errors), 1)
 }
 
+// nolint:lll some test data is just longer
 func TestTokenStream_Highlight(t *testing.T) {
 	type fields struct {
 		text string
@@ -367,6 +368,18 @@ func TestTokenStream_Highlight(t *testing.T) {
 			fields{text: "<p>two, words.</p>"},
 			args{[]int{2}},
 			"<p>two, <em class=\"dhcl\">words.</em></p>",
+		},
+		{
+			"multiple hits no tags",
+			fields{text: "Willem Barentsoen, den stierman Willem Barentsoen."},
+			args{[]int{2, 6}},
+			"Willem <em class=\"dhcl\">Barentsoen,</em> den stierman Willem <em class=\"dhcl\">Barentsoen.</em>",
+		},
+		{
+			"multiple hits with tags",
+			fields{text: "<persname>Willem Barentsoen</persname>, den stierman <persname>Willem Barentsoen</persname>."},
+			args{[]int{2, 6}},
+			"<persname>Willem <em class=\"dhcl\">Barentsoen</em></persname>, den stierman <persname>Willem <em class=\"dhcl\">Barentsoen</em></persname>.",
 		},
 	}
 


### PR DESCRIPTION
When the highlighted term was surrounded by pseudo-tags it would not add the style-class to next hits. It  wrongly assumed that it was a split highlight over tag boundaries.