### PR TITLE
Enable adding of custom tags to fragmentGraphs during indexing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add logging when EAD dataset is deleted [[GH-46]](https://github.com/delving/hub3/pull/46)
 - Config option `maxTreeSize` for setting the maximum size of the navigation tree API [[GH-48]](https://github.com/delving/hub3/pull/48)
 - Config option `processDigital` to enable processing of digital object links in EAD upload [[GH-49]](https://github.com/delving/hub3/pull/49)
-- Config option `datasetTags` to add custom tags to `meta.tags` based on the datasetID [[GH-50]](https://github.com/delving/hub3/pull/50)
+- Config option `datasetTags` to add custom tags to `meta.tags` based on the datasetID [[GH-52]](https://github.com/delving/hub3/pull/52)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 - Support for [test-containers](https://golang.testcontainers.org/) for ikuzo service and storage tests [[GH-27]](https://github.com/delving/hub3/pull/27)
 - GitHub Action configurations and quality control [[GH-29]](https://github.com/delving/hub3/pull/29)
 - Add logging when EAD dataset is deleted [[GH-46]](https://github.com/delving/hub3/pull/46)
-- Config option `maxTreeSize`for setting the maximum size of the navigation tree API [[GH-48]](https://github.com/delving/hub3/pull/48)
-- Config opion `processDigital` to enable processing of digital object links in EAD upload [[GH-49]](https://github.com/delving/hub3/pull/49)
+- Config option `maxTreeSize` for setting the maximum size of the navigation tree API [[GH-48]](https://github.com/delving/hub3/pull/48)
+- Config option `processDigital` to enable processing of digital object links in EAD upload [[GH-49]](https://github.com/delving/hub3/pull/49)
+- Config option `datasetTags` to add custom tags to `meta.tags` based on the datasetID [[GH-50]](https://github.com/delving/hub3/pull/50)
 
 ### Fixed
 

--- a/config/config.go
+++ b/config/config.go
@@ -58,7 +58,13 @@ type RawConfig struct {
 	RDFTagMap     *RDFTagMap `json:"rdfTagMap"`
 	SiteMap       `json:"siteMap"`
 	EAD           `json:"ead"`
-	Logger        *zerolog.Logger
+	DataSetTag    map[string]DataSets `json:"dataSetTag"`
+	DatasetTagMap *RDFTagMap
+	Logger        *zerolog.Logger `json:"logger"`
+}
+
+type DataSets struct {
+	Specs []string
 }
 
 // PostHook contains the configuration for the JSON-LD posthook configuration
@@ -413,6 +419,7 @@ func InitConfig() {
 
 	Config.NameSpaceMap = NewConfigNameSpaceMap(&Config)
 	Config.RDFTagMap = NewRDFTagMap(&Config)
+	Config.DatasetTagMap = NewDataSetTagMap(&Config)
 
 	cleanConfig()
 }

--- a/config/rdftags.go
+++ b/config/rdftags.go
@@ -14,7 +14,9 @@
 
 package config
 
-import "sync"
+import (
+	"sync"
+)
 
 // RDFTag holds tag information how to tag predicate values
 type RDFTag struct {
@@ -52,24 +54,26 @@ type tagPair struct {
 // NewRDFTagMap return
 func NewRDFTagMap(c *RawConfig) *RDFTagMap {
 	pairs := []tagPair{
-		tagPair{"label", c.RDFTag.Label},
-		tagPair{"title", c.RDFTag.Title},
-		tagPair{"owner", c.RDFTag.Owner},
-		tagPair{"thumbnail", c.RDFTag.Thumbnail},
-		tagPair{"landingPage", c.RDFTag.LandingPage},
-		tagPair{"latLong", c.RDFTag.LatLong},
-		tagPair{"isoDate", c.RDFTag.IsoDate},
-		tagPair{"date", c.RDFTag.Date},
-		tagPair{"description", c.RDFTag.Description},
-		tagPair{"subject", c.RDFTag.Subject},
-		tagPair{"collection", c.RDFTag.Collection},
-		tagPair{"subCollection", c.RDFTag.SubCollectection},
-		tagPair{"objectType", c.RDFTag.ObjectType},
-		tagPair{"objectID", c.RDFTag.ObjectID},
-		tagPair{"creator", c.RDFTag.Creator},
-		tagPair{"dateRange", c.RDFTag.DateRange},
+		{"label", c.RDFTag.Label},
+		{"title", c.RDFTag.Title},
+		{"owner", c.RDFTag.Owner},
+		{"thumbnail", c.RDFTag.Thumbnail},
+		{"landingPage", c.RDFTag.LandingPage},
+		{"latLong", c.RDFTag.LatLong},
+		{"isoDate", c.RDFTag.IsoDate},
+		{"date", c.RDFTag.Date},
+		{"description", c.RDFTag.Description},
+		{"subject", c.RDFTag.Subject},
+		{"collection", c.RDFTag.Collection},
+		{"subCollection", c.RDFTag.SubCollectection},
+		{"objectType", c.RDFTag.ObjectType},
+		{"objectID", c.RDFTag.ObjectID},
+		{"creator", c.RDFTag.Creator},
+		{"dateRange", c.RDFTag.DateRange},
 	}
+
 	tagMap := make(map[string][]string)
+
 	for _, pair := range pairs {
 		for _, uri := range pair.uris {
 			values, ok := tagMap[uri]
@@ -77,9 +81,11 @@ func NewRDFTagMap(c *RawConfig) *RDFTagMap {
 				tagMap[uri] = append(values, pair.tag)
 				continue
 			}
+
 			tagMap[uri] = []string{pair.tag}
 		}
 	}
+
 	return &RDFTagMap{
 		TagMap: tagMap,
 	}
@@ -95,5 +101,26 @@ func (rtm *RDFTagMap) Get(uri string) ([]string, bool) {
 	rtm.RLock()
 	label, ok := rtm.TagMap[uri]
 	rtm.RUnlock()
+
 	return label, ok
+}
+
+func NewDataSetTagMap(c *RawConfig) *RDFTagMap {
+	tagMap := make(map[string][]string)
+
+	for tag, specs := range c.DataSetTag {
+		for _, spec := range specs.Specs {
+			values, ok := tagMap[spec]
+			if ok {
+				tagMap[spec] = append(values, tag)
+				continue
+			}
+
+			tagMap[spec] = []string{tag}
+		}
+	}
+
+	return &RDFTagMap{
+		TagMap: tagMap,
+	}
 }

--- a/hub3/ead/description.go
+++ b/hub3/ead/description.go
@@ -33,6 +33,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/delving/hub3/config"
 	c "github.com/delving/hub3/config"
 	"github.com/delving/hub3/hub3/fragments"
 	"github.com/delving/hub3/ikuzo/storage/x/memory"
@@ -729,6 +730,10 @@ func (desc *Description) DescriptionGraph(cfg *NodeConfig, unitInfo *UnitInfo) (
 		NamedGraphURI: fmt.Sprintf("%s/graph", subject),
 		Modified:      fragments.NowInMillis(),
 		Tags:          []string{"eadDesc"},
+	}
+
+	if tags, ok := config.Config.DatasetTagMap.Get(header.Spec); ok {
+		header.Tags = append(header.Tags, tags...)
 	}
 
 	tree := &fragments.Tree{}

--- a/hub3/ead/nodes.go
+++ b/hub3/ead/nodes.go
@@ -131,6 +131,10 @@ func (n *Node) FragmentGraph(cfg *NodeConfig) (*fragments.FragmentGraph, *fragme
 		header.Tags = append(header.Tags, cfg.Tags...)
 	}
 
+	if tags, ok := config.Config.DatasetTagMap.Get(header.Spec); ok {
+		header.Tags = append(header.Tags, tags...)
+	}
+
 	cfg.HubIDs <- &NodeEntry{
 		HubID: header.HubID,
 		Path:  id,

--- a/hub3/ead/parser.go
+++ b/hub3/ead/parser.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"unicode"
 
+	c "github.com/delving/hub3/config"
 	"github.com/delving/hub3/hub3/fragments"
 	"github.com/delving/hub3/ikuzo/domain/domainpb"
 	r "github.com/kiivihal/rdf2go"
@@ -189,6 +190,10 @@ func (cead *Cead) DescriptionGraph(cfg *NodeConfig, unitInfo *UnitInfo) (*fragme
 
 	if len(cfg.Tags) != 0 {
 		header.Tags = append(header.Tags, cfg.Tags...)
+	}
+
+	if tags, ok := c.Config.DatasetTagMap.Get(header.Spec); ok {
+		header.Tags = append(header.Tags, tags...)
 	}
 
 	tree := &fragments.Tree{}

--- a/ikuzo/service/x/bulk/request.go
+++ b/ikuzo/service/x/bulk/request.go
@@ -70,6 +70,10 @@ func (req *Request) createFragmentBuilder(revision int) (*fragments.FragmentBuil
 	fg.Meta.EntryURI = fg.GetAboutURI()
 	fg.Meta.Tags = []string{"narthex", "mdr"}
 
+	if tags, ok := config.Config.DatasetTagMap.Get(req.DatasetID); ok {
+		fg.Meta.Tags = append(fg.Meta.Tags, tags...)
+	}
+
 	fb := fragments.NewFragmentBuilder(fg)
 
 	err := fb.ParseGraph(strings.NewReader(req.Graph), req.GraphMimeType)


### PR DESCRIPTION
Via the config option `dataSetTag` custom tags can be set, for example:

```
[dataSetTag.customTag]
specs = [
    "4.WKF"
]
```

This will add 'customTag' to each record in the `meta.tags` array that
has '4.WKF' in the `meta.spec` field.

These custom tags can then be used for filtering content via
`qf=meta.tags:customTag`.