### PR TITLE
HUB-151 Create c level and Node from p element in dsc element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added 
 
+- Create c level and Node from p element in dsc element. [[GH-56]](https://github.com/delving/hub3/pull/56)
 - Posthook callbacks to `ead.Service` and `index.Service` [[GH-55]](https://github.com/delving/hub3/pull/55)
 - Support for [test-containers](https://golang.testcontainers.org/) for ikuzo service and storage tests [[GH-27]](https://github.com/delving/hub3/pull/27)
 - GitHub Action configurations and quality control [[GH-29]](https://github.com/delving/hub3/pull/29)

--- a/hub3/ead/ead.go
+++ b/hub3/ead/ead.go
@@ -233,48 +233,45 @@ func (dsc *Cdsc) NewNodeList(cfg *NodeConfig) (*NodeList, uint64, error) {
 		nl.Label = append(nl.Label, label.Head)
 	}
 
-	nodes := make([]*Node, 0)
-	errors := make([]string, 0)
-
 	for _, p := range dsc.Cp {
-		cc := p.NewClevel()
+		cc, err := p.NewClevel()
+		if err != nil {
+			return nil, 0, err
+		}
 		node, err := NewNode(CLevel(cc), []string{}, cfg)
 		if err != nil {
-			log.Warn().Msgf("Could not create node from Cp %v", err)
-			errors = append(errors, err.Error())
-			continue
+			return nil, 0, err
 		}
-		nodes = append(nodes, node)
+		if cfg.Nodes != nil {
+			cfg.Nodes <- node
+		}
+
+		// legacy add should not happen if there is a node channel
+		nl.Nodes = append(nl.Nodes, node)
 	}
 
 	for _, cc := range dsc.Numbered {
 		node, err := NewNode(cc, []string{}, cfg)
 		if err != nil {
-			log.Warn().Msgf("Could not create node from numbered %v", err)
-			errors = append(errors, err.Error())
-			continue
+			return nil, 0, err
 		}
-		nodes = append(nodes, node)
+		if cfg.Nodes != nil {
+			cfg.Nodes <- node
+		}
+
+		// legacy add should not happen if there is a node channel
+		nl.Nodes = append(nl.Nodes, node)
 	}
 
 	for _, nn := range dsc.Cc {
 		node, err := NewNode(CLevel(nn), []string{}, cfg)
 		if err != nil {
-			log.Warn().Msgf("Could not create node from c %v", err)
-			errors = append(errors, err.Error())
-			continue
+			return nil, 0, err
 		}
-		nodes = append(nodes, node)
-	}
-
-	if len(errors) > 0 {
-		return nil, 0, fmt.Errorf("error creating NodeList: %s", strings.Join(errors, " - "))
-	}
-
-	for _, node := range nodes {
 		if cfg.Nodes != nil {
 			cfg.Nodes <- node
 		}
+
 		// legacy add should not happen if there is a node channel
 		nl.Nodes = append(nl.Nodes, node)
 	}

--- a/hub3/ead/ead_test.go
+++ b/hub3/ead/ead_test.go
@@ -332,6 +332,25 @@ var _ = Describe("Ead", func() {
 
 		})
 
+		Context("for the p in the dsc", func() {
+			dsc := new(Cdsc)
+			err := parseUtil(dsc, "ead.dsc.xml")
+			It("should not throw an error on create", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("should create a c level series from the p", func() {
+				cfg := NewNodeConfig(context.Background())
+				nodes, nodeCount, err := dsc.NewNodeList(cfg)
+				Expect(nodes).ToNot(BeNil())
+				Expect(nodeCount).To(Equal(uint64(2)))
+				Expect(err).To(BeNil())
+				first := nodes.Nodes[0]
+				Expect(first.CTag).To(Equal("c"))
+				Expect(first.Type).To(Equal("file"))
+				Expect(first.Header.Label[0]).To(Equal("Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. https://www.nationaalarchief.nl/onderzoeken/index/nt00446."))
+			})
+		})
+
 	})
 
 	Context("when being load from file", func() {

--- a/hub3/ead/nodes_test.go
+++ b/hub3/ead/nodes_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Nodes", func() {
 			It("should have parentIDS", func() {
 				triples := node.Triples(cfg)
 				Expect(triples).ToNot(BeEmpty())
-				Expect(triples).To(HaveLen(11))
+				Expect(triples).To(HaveLen(12))
 			})
 
 		})

--- a/hub3/ead/nodes_test.go
+++ b/hub3/ead/nodes_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Nodes", func() {
 			It("should have parentIDS", func() {
 				triples := node.Triples(cfg)
 				Expect(triples).ToNot(BeEmpty())
-				Expect(triples).To(HaveLen(12))
+				Expect(triples).To(HaveLen(11))
 			})
 
 		})

--- a/hub3/ead/parser.go
+++ b/hub3/ead/parser.go
@@ -361,9 +361,12 @@ func (ut *Cunittitle) Title() string {
 }
 
 // NewClevel creates a fake c level series struct from the paragraph text.
-func (cp *Cp) NewClevel() *Cc {
+func (cp *Cp) NewClevel() (*Cc, error) {
 	fakeC := fmt.Sprintf(`<c level="file"><did><unittitle>%s</unittitle></did></c>`, cp.Raw)
 	cc := &Cc{}
-	_ = xml.Unmarshal([]byte(fakeC), cc)
-	return cc
+	err := xml.Unmarshal([]byte(fakeC), cc)
+	if err != nil {
+		return nil, err
+	}
+	return cc, nil
 }

--- a/hub3/ead/parser.go
+++ b/hub3/ead/parser.go
@@ -359,3 +359,11 @@ func (ca *Cabstract) CleanAbstract() []string {
 func (ut *Cunittitle) Title() string {
 	return sanitizer.Sanitize(strings.TrimSpace(fmt.Sprintf("%s", ut.Raw)))
 }
+
+// NewClevel creates a fake c level series struct from the paragraph text.
+func (cp *Cp) NewClevel() *Cc {
+	fakeC := fmt.Sprintf(`<c level="file"><did><unittitle>%s</unittitle></did></c>`, cp.Raw)
+	cc := &Cc{}
+	_ = xml.Unmarshal([]byte(fakeC), cc)
+	return cc
+}

--- a/hub3/ead/testdata/ead/ead.dsc.xml
+++ b/hub3/ead/testdata/ead/ead.dsc.xml
@@ -1,0 +1,13 @@
+<dsc type="combined">
+  <head>Beschrijving van de series en archiefbestanddelen</head>
+  <p>Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. <extref linktype="simple" show="new" actuate="onrequest" href="https://www.nationaalarchief.nl/onderzoeken/index/nt00446">https://www.nationaalarchief.nl/onderzoeken/index/nt00446</extref>.</p>
+  <c level="file">
+    <did>
+      <unitid identifier="44345203" type="ABS">1</unitid>
+      <unitid audience="internal" type="handle">http://hdl.handle.net/10648/833c843f-a492-40e2-8029-feeaf16a88ed</unitid>
+      <unittitle>Agenda van ingekomen en uitgaande stukken.</unittitle>
+      <unitdate calendar="gregorian" normal="1937/1938" era="ce">1937-1938</unitdate>
+      <physdesc>1 katern</physdesc>
+    </did>
+  </c>
+</dsc>


### PR DESCRIPTION
Given XML
```xml
<dsc type="combined">
  <head>Beschrijving van de series en archiefbestanddelen</head>
  <p>Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. <extref linktype="simple" show="new" actuate="onrequest" href="https://www.nationaalarchief.nl/onderzoeken/index/nt00446">https://www.nationaalarchief.nl/onderzoeken/index/nt00446</extref>.</p>
  <c level="file"></c>
</dsc>

```
Op dit moment wordt inderdaad de head en p onder 'dsc combined' niet meegenomen in of de description API of de tree API.
De makkelijkste oplossing zou zijn om deze informatie te veranderen tijdens het parsen in een dummy c-level zoals als is gebeurd met `<unittitle>BELANGRIJKE MEDEDELING VOOR DE ONDERZOEKER</unittitle>` in het voorbeeld hierboven. Dan weten we zeker dat het in de rest ead verwerkings-pijplijn goed gaat.