### PR TITLE
Extract extref from p when found and add it to the odd.

### DIFF
--- a/hub3/ead/ead_test.go
+++ b/hub3/ead/ead_test.go
@@ -347,7 +347,7 @@ var _ = Describe("Ead", func() {
 				first := nodes.Nodes[0]
 				Expect(first.CTag).To(Equal("c"))
 				Expect(first.Type).To(Equal("file"))
-				Expect(first.Header.Label[0]).To(Equal("Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. https://www.nationaalarchief.nl/onderzoeken/index/nt00446."))
+				Expect(first.Header.Label[0]).To(Equal("Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam."))
 			})
 		})
 

--- a/hub3/ead/parser.go
+++ b/hub3/ead/parser.go
@@ -362,7 +362,21 @@ func (ut *Cunittitle) Title() string {
 
 // NewClevel creates a fake c level series struct from the paragraph text.
 func (cp *Cp) NewClevel() (*Cc, error) {
-	fakeC := fmt.Sprintf(`<c level="file"><did><unittitle>%s</unittitle></did></c>`, cp.Raw)
+	title := strings.Replace(cp.P, ". .", ".", 1)
+	odd := ""
+	if len(cp.Cextref) > 0 {
+		refs := make([]string, 0)
+		for _, cex := range cp.Cextref {
+			cex.Extref = ""
+			x, err := xml.Marshal(cex)
+			if err != nil {
+				return nil, err
+			}
+			refs = append(refs, fmt.Sprintf("<p>%s</p>", string(x)))
+		}
+		odd = fmt.Sprintf("<odd>%s</odd>", strings.Join(refs, ""))
+	}
+	fakeC := fmt.Sprintf(`<c level="file"><did><unittitle>%s</unittitle></did>%s</c>`, title, odd)
 	cc := &Cc{}
 	err := xml.Unmarshal([]byte(fakeC), cc)
 	if err != nil {


### PR DESCRIPTION
Given xml
```
<dsc type="combined">
  <head>Beschrijving van de series en archiefbestanddelen</head>
  <p>Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. <extref linktype="simple" show="new" actuate="onrequest" href="https://www.nationaalarchief.nl/onderzoeken/index/nt00446">https://www.nationaalarchief.nl/onderzoeken/index/nt00446</extref>.</p>
  <c level="file">
</dsc>
```
The last pull request turned the `<p>...</p>` in the tree into a Cc. The `<p>` element however has an `<extref>` child that should be linkable and should not be set in the `<unittitle>`
This pull request extracts the extref from the p and creates an `<odd>` element where the extrefs can be placed.