### PR TITLE
Add core changes for clearing restrictions.

### DIFF
--- a/hub3/ead/ead.go
+++ b/hub3/ead/ead.go
@@ -76,6 +76,7 @@ type NodeConfig struct {
 	ContentIdentical        bool
 	Nodes                   chan *Node
 	ProcessDigital          bool
+	ProcessAccessTime       time.Time
 	m                       sync.Mutex
 	Tags                    []string
 }

--- a/ikuzo/service/x/ead/meta.go
+++ b/ikuzo/service/x/ead/meta.go
@@ -34,6 +34,7 @@ type Meta struct {
 	FileSize              uint64
 	Revision              int32
 	ProcessDigital        bool
+	ProcessAccessTime     time.Time
 	Created               bool
 	ProcessingDuration    time.Duration `json:"processingDuration,omitempty"`
 	ProcessingDurationFmt string        `json:"processingDurationFmt,omitempty"`


### PR DESCRIPTION
During indexing for each inventory a restriction is calculated if the material is not publicly available. This addition makes it possible to run a cron-job each day (for example after midnight) to find Archives that have inventories with expired restrictions. In that case, the Archive is re-indexed and the restrictions are removed.