### PR TITLE
Make archref element a link as well.

### DIFF
--- a/hub3/ead/description.go
+++ b/hub3/ead/description.go
@@ -311,7 +311,7 @@ func (ib *itemBuilder) push(se xml.StartElement) error {
 		}
 	case "event":
 		id.Type = Event
-	case "extref", "extptr":
+	case "extref", "extptr", "archref":
 		err := ib.close()
 		if err != nil {
 			return err


### PR DESCRIPTION
Consider this XML in de the description

```
<separatedmaterial>
                <head>Afgescheiden archiefmateriaal</head>
                <p>De overige stukken van de commissie die de VP-dossiers heeft gevormd, bevinden zich in archief Cie. aangifte overlijden vermisten <archref actuate="onrequest" href="http://www.google.nl/collectie/archief/ead/index/eadid/2.09.34.01" linktype="simple" show="new">(archiefinventaris 2.09.34.01)</archref>.</p>
</separatedmaterial>
```

The archref element is currently stored as a paragraph type in the description API.
This change changes the archref element type to a link type with the relevant attributes. This is needed so we can link archref elements within the description API. 