### PR TITLE
Feature/sort fields store proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added 
 
+- Sort fields in the fieldMap resource.NewFields because the map is always unordered. Store protobuf messages in resource and use pointers instead of values for protobuf field in FragmentGraph. [[GH-63]](https://github.com/delving/hub3/pull/63)
 - Update to v2 RAML API documentation [[GH-59]](https://github.com/delving/hub3/pull/59)
 - Extract extref from p when found and add it to the odd. [[GH-58]](https://github.com/delving/hub3/pull/58)
 - Create c level and Node from p element in dsc element. [[GH-56]](https://github.com/delving/hub3/pull/56)

--- a/hub3/ead/mets.go
+++ b/hub3/ead/mets.go
@@ -426,7 +426,7 @@ func fragmentGraph(cfg *NodeConfig, fa *eadpb.FindingAid, file *eadpb.File) (*fr
 		return fg, fmt.Errorf("unable to marshal protobuf message: %#v", err)
 	}
 
-	fg.ProtoBuf = fragments.ProtoBuf{
+	fg.ProtoBuf = &fragments.ProtoBuf{
 		MessageType: "eadpb.File",
 		Data:        fmt.Sprintf("%x", b),
 	}
@@ -526,7 +526,7 @@ func findingAidFragmentGraph(cfg *NodeConfig, fa *eadpb.FindingAid) (*fragments.
 		return fg, fmt.Errorf("unable to marshal protobuf message: %#v", err)
 	}
 
-	fg.ProtoBuf = fragments.ProtoBuf{
+	fg.ProtoBuf = &fragments.ProtoBuf{
 		MessageType: "eadpb.FindingAid",
 		Data:        fmt.Sprintf("%x", b),
 	}

--- a/hub3/fragments/resource.go
+++ b/hub3/fragments/resource.go
@@ -356,7 +356,7 @@ type FragmentGraph struct {
 	JSONLD     []map[string]interface{}  `json:"jsonld,omitempty"`
 	Fields     map[string][]string       `json:"fields,omitempty"`
 	Highlights []*ResourceEntryHighlight `json:"highlights,omitempty"`
-	ProtoBuf   ProtoBuf                  `json:"protobuf,omitempty"`
+	ProtoBuf   *ProtoBuf                 `json:"protobuf,omitempty"`
 }
 
 func (fg *FragmentGraph) Marshal() ([]byte, error) {

--- a/hub3/fragments/resource.go
+++ b/hub3/fragments/resource.go
@@ -1415,19 +1415,31 @@ func (fg *FragmentGraph) NewFields(tq *memory.TextQuery, fields ...string) map[s
 	fg.Fields = make(map[string][]string)
 
 	if tq == nil {
-		for k, v := range fieldMap {
-			fields := []string{}
-			for vk := range v {
-				if vk != "" {
-					fields = append(fields, vk)
+		type posMap struct {
+			Key   string
+			Value int
+		}
+		for name, u := range fieldMap {
+			// The map u from fieldMap is always unordered
+			posItems := make([]posMap, 0)
+			for key, position := range u {
+				if key != "" {
+					posItems = append(posItems, posMap{key, position})
 				}
 			}
-			if len(fields) > 0 {
-				fg.Fields[k] = fields
+			if len(posItems) > 0 {
+				sort.Slice(posItems, func(i, j int) bool {
+					return posItems[i].Value < posItems[j].Value
+				})
+				sortValues := make([]string, 0)
+				for _, n := range posItems {
+					sortValues = append(sortValues, n.Key)
+				}
+				fg.Fields[name] = sortValues
 			}
 		}
 
-		log.Printf("flat fields: %#v", fg.Fields)
+		// log.Printf("flat fields: %#v", fg.Fields)
 
 		return fg.Fields
 	}

--- a/hub3/fragments/resource.go
+++ b/hub3/fragments/resource.go
@@ -356,7 +356,7 @@ type FragmentGraph struct {
 	JSONLD     []map[string]interface{}  `json:"jsonld,omitempty"`
 	Fields     map[string][]string       `json:"fields,omitempty"`
 	Highlights []*ResourceEntryHighlight `json:"highlights,omitempty"`
-	ProtoBuf   ProtoBuf                  `json:"-"`
+	ProtoBuf   ProtoBuf                  `json:"protobuf,omitempty"`
 }
 
 func (fg *FragmentGraph) Marshal() ([]byte, error) {

--- a/hub3/server/http/handlers/search.go
+++ b/hub3/server/http/handlers/search.go
@@ -353,16 +353,20 @@ func ProcessSearchRequest(w http.ResponseWriter, r *http.Request, searchRequest 
 		for _, rec := range records {
 			rec.NewFields(textQuery)
 			rec.Resources = nil
+			rec.Summary = nil
+			rec.ProtoBuf = nil
 		}
 	case fragments.ItemFormatType_SUMMARY:
 		for _, rec := range records {
 			rec.NewResultSummary()
 			rec.Resources = nil
+			rec.ProtoBuf = nil
 		}
 	case fragments.ItemFormatType_JSONLD:
 		for _, rec := range records {
 			rec.NewJSONLD()
 			rec.Resources = nil
+			rec.ProtoBuf = nil
 		}
 	case fragments.ItemFormatType_TREE:
 		leafs := []*fragments.Tree{}
@@ -643,6 +647,8 @@ func ProcessSearchRequest(w http.ResponseWriter, r *http.Request, searchRequest 
 	case fragments.ItemFormatType_GROUPED:
 		for _, rec := range records {
 			_, err = rec.NewGrouped()
+			rec.ProtoBuf = nil
+			rec.Summary = nil
 
 			if err != nil {
 				render.Status(r, http.StatusInternalServerError)


### PR DESCRIPTION
1. The struct FragmentGraph needs the json protobuf marshalling directive so Elasticsearch stores these protobuf message or else the /api/pb/viewer/list will fail
2. The resource.NewFields has a fieldMap map that has unsorted sub maps. But we need to preserve the order of the resource entries in fg.Fields.