### PR TITLE
Feature/v1 indexing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Config option `datasetTags` to add custom tags to `meta.tags` based on the datasetID [[GH-52]](https://github.com/delving/hub3/pull/52)
 
 ### Fixed
+- Fix for graph traversal when creating v1 indexing records [[GH-64]](https://github.com/delving/hub3/pull/64)
 - use "<br/>" instead of "<lb/>" in the description API output [[GH-54]](https://github.com/delving/hub3/pull/54)
 - Code quality improvements reported by SonarCloud and golangci-lint [[GH-35]](https://github.com/delving/hub3/pull/35)
 - Concurrent retrieval of RDF for webresources now uses errgroup [[GH-44]](https://github.com/delving/hub3/pull/44)

--- a/ikuzo/service/x/bulk/request.go
+++ b/ikuzo/service/x/bulk/request.go
@@ -87,7 +87,7 @@ func (req *Request) createFragmentBuilder(revision int) (*fragments.FragmentBuil
 func (req *Request) processV1(ctx context.Context, fb *fragments.FragmentBuilder, bi index.BulkIndex) error {
 	fb.GetSortedWebResources(ctx)
 
-	indexDoc, err := fragments.CreateV1IndexDoc(fb)
+	indexDoc, err := fragments.CreateV1IndexDoc(fb, req.RecordType)
 	if err != nil {
 		log.Info().Msgf("Unable to create index doc: %s", err)
 		return err


### PR DESCRIPTION
This pull-request contains some fixes to the v1 bulk indexing API. 

- when indexing via the bulk index API the recordType is also included for indexing. 'mdr' and 'narthex_record' are supported as the defaults when received from Nathex

- due to a bug in the external RDF library when using rdf2go.Graph().All() does not return all the matching triples. This working around using rd2go.Graph().IterTriples() makes sure that resolving the RDF labels returns all the labels.