### PR TITLE
Replace extref only code with P contents extracted from the cp.Raw.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added 
 
-- Change paragraph's into clevels with and add them to the odd. [[GH-66]](https://github.com/delving/hub3/pull/66)
+- Change paragraph's into clevels and add them to the odd. [[GH-66]](https://github.com/delving/hub3/pull/66)
 - Sort fields in the fieldMap resource.NewFields because the map is always unordered. Store protobuf messages in resource and use pointers instead of values for protobuf field in FragmentGraph. [[GH-63]](https://github.com/delving/hub3/pull/63)
 - Update to v2 RAML API documentation [[GH-59]](https://github.com/delving/hub3/pull/59)
 - Extract extref from p when found and add it to the odd. [[GH-58]](https://github.com/delving/hub3/pull/58)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added 
 
+- Change paragraph's into clevels with and add them to the odd. [[GH-66]](https://github.com/delving/hub3/pull/66)
 - Sort fields in the fieldMap resource.NewFields because the map is always unordered. Store protobuf messages in resource and use pointers instead of values for protobuf field in FragmentGraph. [[GH-63]](https://github.com/delving/hub3/pull/63)
 - Update to v2 RAML API documentation [[GH-59]](https://github.com/delving/hub3/pull/59)
 - Extract extref from p when found and add it to the odd. [[GH-58]](https://github.com/delving/hub3/pull/58)

--- a/hub3/ead/ead_test.go
+++ b/hub3/ead/ead_test.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	r "github.com/kiivihal/rdf2go"
 
 	. "github.com/delving/hub3/hub3/ead"
 	. "github.com/onsi/ginkgo"
@@ -347,27 +350,39 @@ var _ = Describe("Ead", func() {
 			})
 			It("should have a archref p element", func() {
 				archref := nodes.Nodes[0]
+				triples := archref.Triples(cfg)
+				oddString := OddStringFromTriple(triples)
 				Expect(archref.CTag).To(Equal("c"))
 				Expect(archref.Type).To(Equal("file"))
 				Expect(archref.Header.Label[0]).To(Equal("Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. archref link ."))
+				Expect(oddString).To(Equal(`<p> <archref linktype="simple" show="new" actuate="onrequest" href="https://www.nationaalarchief.nl/onderzoeken/index/nt00446">https://www.nationaalarchief.nl/onderzoeken/index/nt00446</archref>.</p>`))
 			})
 			It("should have a extref p element", func() {
 				extref := nodes.Nodes[1]
+				triples := extref.Triples(cfg)
+				oddString := OddStringFromTriple(triples)
 				Expect(extref.CTag).To(Equal("c"))
 				Expect(extref.Type).To(Equal("file"))
 				Expect(extref.Header.Label[0]).To(Equal("Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. extref link ."))
+				Expect(oddString).To(Equal(`<p> <extref linktype="simple" show="new" actuate="onrequest" href="https://www.nationaalarchief.nl/onderzoeken/index/nt00446">https://www.nationaalarchief.nl/onderzoeken/index/nt00446</extref>.</p>`))
 			})
 			It("should have a bibref p element", func() {
 				bibref := nodes.Nodes[2]
+				triples := bibref.Triples(cfg)
+				oddString := OddStringFromTriple(triples)
 				Expect(bibref.CTag).To(Equal("c"))
 				Expect(bibref.Type).To(Equal("file"))
 				Expect(bibref.Header.Label[0]).To(Equal("Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. bibref link ."))
+				Expect(oddString).To(Equal("<p> <bibref linktype=\"simple\" show=\"new\" actuate=\"onrequest\" href=\"https://www.nationaalarchief.nl/onderzoeken/index/nt00446\">https://www.nationaalarchief.nl/onderzoeken/index/nt00446</bibref>.</p>"))
 			})
 			It("should have a ref p element", func() {
 				ref := nodes.Nodes[3]
+				triples := ref.Triples(cfg)
+				oddString := OddStringFromTriple(triples)
 				Expect(ref.CTag).To(Equal("c"))
 				Expect(ref.Type).To(Equal("file"))
 				Expect(ref.Header.Label[0]).To(Equal("Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. ref link . En nu staat er nog wat tekst achter."))
+				Expect(oddString).To(Equal(`<p>Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. ref link <ref linktype="simple" show="new" actuate="onrequest" href="https://www.nationaalarchief.nl/onderzoeken/index/nt00446">https://www.nationaalarchief.nl/onderzoeken/index/nt00446</ref>. En nu staat er nog wat tekst achter.</p>`))
 			})
 		})
 
@@ -451,6 +466,15 @@ func parseUtil(node interface{}, fName string) error {
 		return err
 	}
 	return nil
+}
+
+func OddStringFromTriple(triple []*r.Triple) string {
+	for _, s := range triple {
+		if strings.HasSuffix(s.Predicate.RawValue(), "odd") {
+			return s.Object.RawValue()
+		}
+	}
+	return ""
 }
 
 func TestNodeDate_ValidDateNormal(t *testing.T) {

--- a/hub3/ead/ead_test.go
+++ b/hub3/ead/ead_test.go
@@ -335,19 +335,39 @@ var _ = Describe("Ead", func() {
 		Context("for the p in the dsc", func() {
 			dsc := new(Cdsc)
 			err := parseUtil(dsc, "ead.dsc.xml")
+			cfg := NewNodeConfig(context.Background())
+			nodes, nodeCount, err := dsc.NewNodeList(cfg)
 			It("should not throw an error on create", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
-			It("should create a c level series from the p", func() {
-				cfg := NewNodeConfig(context.Background())
-				nodes, nodeCount, err := dsc.NewNodeList(cfg)
+			It("should create 5 c level series from the p's", func() {
 				Expect(nodes).ToNot(BeNil())
-				Expect(nodeCount).To(Equal(uint64(2)))
+				Expect(nodeCount).To(Equal(uint64(5)))
 				Expect(err).To(BeNil())
-				first := nodes.Nodes[0]
-				Expect(first.CTag).To(Equal("c"))
-				Expect(first.Type).To(Equal("file"))
-				Expect(first.Header.Label[0]).To(Equal("Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam."))
+			})
+			It("should have a archref p element", func() {
+				archref := nodes.Nodes[0]
+				Expect(archref.CTag).To(Equal("c"))
+				Expect(archref.Type).To(Equal("file"))
+				Expect(archref.Header.Label[0]).To(Equal("Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. archref link ."))
+			})
+			It("should have a extref p element", func() {
+				extref := nodes.Nodes[1]
+				Expect(extref.CTag).To(Equal("c"))
+				Expect(extref.Type).To(Equal("file"))
+				Expect(extref.Header.Label[0]).To(Equal("Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. extref link ."))
+			})
+			It("should have a bibref p element", func() {
+				bibref := nodes.Nodes[2]
+				Expect(bibref.CTag).To(Equal("c"))
+				Expect(bibref.Type).To(Equal("file"))
+				Expect(bibref.Header.Label[0]).To(Equal("Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. bibref link ."))
+			})
+			It("should have a ref p element", func() {
+				ref := nodes.Nodes[3]
+				Expect(ref.CTag).To(Equal("c"))
+				Expect(ref.Type).To(Equal("file"))
+				Expect(ref.Header.Label[0]).To(Equal("Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. ref link . En nu staat er nog wat tekst achter."))
 			})
 		})
 

--- a/hub3/ead/parser.go
+++ b/hub3/ead/parser.go
@@ -363,20 +363,10 @@ func (ut *Cunittitle) Title() string {
 // NewClevel creates a fake c level series struct from the paragraph text.
 func (cp *Cp) NewClevel() (*Cc, error) {
 	title := strings.Replace(cp.P, ". .", ".", 1)
-	odd := ""
-	if len(cp.Cextref) > 0 {
-		refs := make([]string, 0)
-		for _, cex := range cp.Cextref {
-			cex.Extref = ""
-			x, err := xml.Marshal(cex)
-			if err != nil {
-				return nil, err
-			}
-			refs = append(refs, fmt.Sprintf("<p>%s</p>", string(x)))
-		}
-		odd = fmt.Sprintf("<odd>%s</odd>", strings.Join(refs, ""))
-	}
-	fakeC := fmt.Sprintf(`<c level="file"><did><unittitle>%s</unittitle></did>%s</c>`, title, odd)
+	trimmedTitle := strings.TrimSpace(strings.TrimSuffix(title, "."))
+	rawP := string(cp.Raw)
+	replacedP := strings.Replace(rawP, trimmedTitle, "", 1)
+	fakeC := fmt.Sprintf(`<c level="file"><did><unittitle>%s</unittitle></did><odd><p>%s</p></odd></c>`, title, replacedP)
 	cc := &Cc{}
 	err := xml.Unmarshal([]byte(fakeC), cc)
 	if err != nil {

--- a/hub3/ead/testdata/ead/ead.dsc.xml
+++ b/hub3/ead/testdata/ead/ead.dsc.xml
@@ -1,6 +1,9 @@
 <dsc type="combined">
   <head>Beschrijving van de series en archiefbestanddelen</head>
-  <p>Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. <extref linktype="simple" show="new" actuate="onrequest" href="https://www.nationaalarchief.nl/onderzoeken/index/nt00446">https://www.nationaalarchief.nl/onderzoeken/index/nt00446</extref>.</p>
+  <p>Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. archref link <archref linktype="simple" show="new" actuate="onrequest" href="https://www.nationaalarchief.nl/onderzoeken/index/nt00446">https://www.nationaalarchief.nl/onderzoeken/index/nt00446</archref>.</p>
+  <p>Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. extref link <extref linktype="simple" show="new" actuate="onrequest" href="https://www.nationaalarchief.nl/onderzoeken/index/nt00446">https://www.nationaalarchief.nl/onderzoeken/index/nt00446</extref>.</p>
+  <p>Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. bibref link <bibref linktype="simple" show="new" actuate="onrequest" href="https://www.nationaalarchief.nl/onderzoeken/index/nt00446">https://www.nationaalarchief.nl/onderzoeken/index/nt00446</bibref>.</p>
+  <p>Let op: deze inventaris is alleen voor het inzien van de dossiers. Kijk in de index voor het zoeken op naam. ref link <ref linktype="simple" show="new" actuate="onrequest" href="https://www.nationaalarchief.nl/onderzoeken/index/nt00446">https://www.nationaalarchief.nl/onderzoeken/index/nt00446</ref>. En nu staat er nog wat tekst achter.</p>
   <c level="file">
     <did>
       <unitid identifier="44345203" type="ABS">1</unitid>


### PR DESCRIPTION
Replacing the extref only with the stripped / replaced raw p so all types of links can be rendered. And also text outside anchor elements can exist in the P