### PR TITLE
Make the logging-label for errors configurable.

### DIFF
--- a/ikuzo/ikuzoctl/cmd/config/logging.go
+++ b/ikuzo/ikuzoctl/cmd/config/logging.go
@@ -21,10 +21,11 @@ import (
 )
 
 type Logging struct {
-	DevMode       bool   `json:"devmode"`
-	Level         string `json:"level"`
-	WithCaller    bool   `json:"withCaller"`
-	ConsoleLogger bool   `json:"consoleLogger"`
+	DevMode        bool   `json:"devmode"`
+	Level          string `json:"level"`
+	WithCaller     bool   `json:"withCaller"`
+	ConsoleLogger  bool   `json:"consoleLogger"`
+	ErrorFieldName string `json:"errorFieldName"`
 }
 
 func (l *Logging) AddOptions(cfg *Config) error {
@@ -45,5 +46,6 @@ func (l *Logging) GetConfig() logger.Config {
 		LogLevel:            logger.ParseLogLevel(l.Level),
 		WithCaller:          l.WithCaller,
 		EnableConsoleLogger: l.ConsoleLogger,
+		ErrorFieldName:      l.ErrorFieldName,
 	}
 }

--- a/ikuzo/logger/logger.go
+++ b/ikuzo/logger/logger.go
@@ -113,6 +113,8 @@ type Config struct {
 	// WithCaller logs the path and linenumber of the caller.
 	// This should not be used in production
 	WithCaller bool
+	// ErrorFieldName is the label for Go errors in the JSON output. (default: error)
+	ErrorFieldName string
 }
 
 // NewLogger creates zerolog.Logger with sensible defaults
@@ -148,6 +150,7 @@ func NewLogger(cfg Config) CustomLogger {
 	}
 
 	zerolog.TimeFieldFormat = time.RFC3339Nano
+	zerolog.ErrorFieldName = cfg.ErrorFieldName
 
 	return CustomLogger{loggerContext.Logger().Level(cfg.LogLevel.toZeroLog())}
 }


### PR DESCRIPTION
The default label 'error' in the json-logger causes some conflicts when
the data is loading into the ELK-stack. Now you can for example map it
to 'error.message'.