### PR TITLE
HUB-188 Pass dao errors to task.Meta for logging purposes.

### DIFF
--- a/ikuzo/service/x/ead/service.go
+++ b/ikuzo/service/x/ead/service.go
@@ -608,6 +608,8 @@ func (s *Service) Process(parentCtx context.Context, t *Task) error {
 
 		t.Meta.Clevels = cfg.Counter.GetCount()
 		t.Meta.DaoLinks = cfg.MetsCounter.GetCount()
+		t.Meta.DaoErrors = cfg.MetsCounter.GetErrorCount()
+		t.Meta.DaoErrorLinks = cfg.MetsCounter.GetErrors()
 		t.Meta.TotalRecordsPublished = atomic.LoadUint64(&cfg.RecordsCreatedCounter)
 		t.Meta.DigitalObjects = cfg.MetsCounter.GetDigitalObjectCount()
 


### PR DESCRIPTION
Bram found the DaoErrors was always empty in the logline even when there were METS urls incorrect or not reachable. The line in task.go read the t.Meta.DaoErrors - but that property was never set.
```
	t.log().Info().
		Dur("processing", t.Meta.ProcessingDuration).
		Uint64("inventories", t.Meta.Clevels).
		Uint64("metsFiles", t.Meta.DaoLinks).
		Uint64("publishedToIndex", t.Meta.TotalRecordsPublished).
		Uint64("digitalObjects", t.Meta.DigitalObjects).
		Bool("created", t.Meta.Created).
		Uint64("metsRetrieveErrors", t.Meta.DaoErrors).
		Strs("metsErrorLinks ", t.Meta.DaoErrorLinks).
		Uint64("fileSize", t.Meta.FileSize).
		Msg("finished processing")

```