### PR TITLE
Feature/v0.2.0/index field type mismatches

### DIFF
--- a/hub3/ead/dao.go
+++ b/hub3/ead/dao.go
@@ -212,7 +212,7 @@ func (c *DaoClient) StoreMets(cfg *DaoConfig) error {
 
 func (c *DaoClient) DefaultDaoFn(cfg *DaoConfig) error {
 	if !strings.Contains(cfg.Link, "/gaf/api/mets/v1/") {
-		return fmt.Errorf("invalid daolink to GAF: %s", cfg.Link)
+		return fmt.Errorf("invalid daolink to GAF: ' %s '", cfg.Link)
 	}
 
 	return c.PublishFindingAid(cfg)

--- a/hub3/ead/ead.go
+++ b/hub3/ead/ead.go
@@ -141,6 +141,7 @@ func NewNodeConfig(ctx context.Context) *NodeConfig {
 		Counter: &NodeCounter{},
 		MetsCounter: &MetsCounter{
 			uniqueCounter: map[string]int{},
+			inError:       map[string]string{},
 		},
 		labels: make(map[string]string),
 		HubIDs: make(chan *NodeEntry, 100),
@@ -152,7 +153,7 @@ type MetsCounter struct {
 	counter        uint64
 	digitalObjects uint64
 	errors         uint64
-	inError        []string
+	inError        map[string]string
 	uniqueCounter  map[string]int
 	m              sync.Mutex
 }
@@ -195,14 +196,14 @@ func (mc *MetsCounter) GetErrorCount() uint64 {
 	return atomic.LoadUint64(&mc.errors)
 }
 
-func (mc *MetsCounter) AppendError(err string) {
+func (mc *MetsCounter) AppendError(unitID string, errMsg string) {
 	mc.IncrementError()
 	mc.m.Lock()
 	defer mc.m.Unlock()
-	mc.inError = append(mc.inError, err)
+	mc.inError[unitID] = errMsg
 }
 
-func (mc *MetsCounter) GetErrors() []string {
+func (mc *MetsCounter) GetErrors() map[string]string {
 	return mc.inError
 }
 

--- a/hub3/ead/mets.go
+++ b/hub3/ead/mets.go
@@ -336,7 +336,7 @@ func getEventMETS(level zerolog.Level, archiveID, inventoryID string, eventType 
 func logMETSError(archiveID, inventoryID, format string, a ...interface{}) {
 	getEventMETS(zerolog.ErrorLevel, archiveID, inventoryID, METSCreate).
 		Str("error.message", fmt.Sprint(format, a)).
-		Str("status", "failed").
+		Str("metsStatus", "failed").
 		Send()
 }
 

--- a/hub3/ead/nodes.go
+++ b/hub3/ead/nodes.go
@@ -217,7 +217,7 @@ func CreateTree(cfg *NodeConfig, n *Node, hubID string, id string) *fragments.Tr
 						Str("uuid", daoCfg.UUID).
 						Str("url", daoCfg.Link).
 						Msg("unable to process dao link")
-					cfg.MetsCounter.AppendError(err.Error())
+					cfg.MetsCounter.AppendError(daoCfg.InventoryID, err.Error())
 					return tree
 				}
 

--- a/hub3/models/dataset.go
+++ b/hub3/models/dataset.go
@@ -156,12 +156,12 @@ type Access struct {
 
 // DaoStats holds the stats for EAD digital objects extracted from METS links.
 type DaoStats struct {
-	ExtractedLinks uint64         `json:"extractedLinks"`
-	RetrieveErrors uint64         `json:"retrieveErrors"`
-	DigitalObjects uint64         `json:"digitalObjects"`
-	Errors         []string       `json:"errors"`
-	UniqueLinks    uint64         `json:"uniqueLinks"`
-	DuplicateLinks map[string]int `json:"duplicateLinks"`
+	ExtractedLinks uint64            `json:"extractedLinks"`
+	RetrieveErrors uint64            `json:"retrieveErrors"`
+	DigitalObjects uint64            `json:"digitalObjects"`
+	Errors         map[string]string `json:"errors"`
+	UniqueLinks    uint64            `json:"uniqueLinks"`
+	DuplicateLinks map[string]int    `json:"duplicateLinks"`
 }
 
 // createDatasetURI creates a RDF uri for the dataset based Config RDF BaseUrl

--- a/ikuzo/middleware/logger.go
+++ b/ikuzo/middleware/logger.go
@@ -15,8 +15,10 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/delving/hub3/ikuzo/domain"
@@ -92,8 +94,19 @@ func LogParamsAsDict(params url.Values) *zerolog.Event {
 
 		var nonEmpty bool
 
+		alteredKey := ""
 		for _, v := range values {
 			if v != "" {
+				if key == "qf" {
+					parts := strings.Split(v, ":")
+					if len(parts) == 2 {
+						alteredKey = fmt.Sprintf("%s.%s", key, parts[0])
+						v = parts[1]
+					}
+					if len(parts) == 1 {
+						alteredKey = "qf.value"
+					}
+				}
 				arr = arr.Str(v)
 
 				if !nonEmpty {
@@ -103,6 +116,9 @@ func LogParamsAsDict(params url.Values) *zerolog.Event {
 		}
 
 		if nonEmpty {
+			if alteredKey != "" {
+				key = alteredKey
+			}
 			dict = dict.Array(key, arr)
 		}
 	}

--- a/ikuzo/middleware/logger_test.go
+++ b/ikuzo/middleware/logger_test.go
@@ -81,6 +81,26 @@ func Test_LogParamsAsDict(t *testing.T) {
 			queryParams: "q=",
 			want:        `{"params":{}}`,
 		},
+		{
+			name:        "params with qf as object",
+			queryParams: "qf.dateRange=ead-rdf_periodDesc:1189~1863",
+			want:        `{"params":{"qf.dateRange":["ead-rdf_periodDesc:1189~1863"]}}`,
+		},
+		{
+			name:        "params with qf as string needs to be stored as object",
+			queryParams: "qf=meta.tags:suriname",
+			want:        `{"params":{"qf.meta.tags":["suriname"]}}`,
+		},
+		{
+			name:        "multi qf params",
+			queryParams: "qf=meta.tags:suriname&qf=meta.tags:ead",
+			want:        `{"params":{"qf.meta.tags":["suriname","ead"]}}`,
+		},
+		{
+			name:        "simple string. store as qf.value object",
+			queryParams: "qf=thisCanHappen",
+			want:        `{"params":{"qf.value":["thisCanHappen"]}}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ikuzo/service/x/ead/meta.go
+++ b/ikuzo/service/x/ead/meta.go
@@ -27,7 +27,7 @@ type Meta struct {
 	Clevels               uint64
 	DaoLinks              uint64
 	DaoErrors             uint64
-	DaoErrorLinks         []string
+	DaoErrorLinks         map[string]string
 	Tags                  []string
 	TotalRecordsPublished uint64
 	DigitalObjects        uint64
@@ -43,4 +43,12 @@ type Meta struct {
 // getSourcePath returns full path to the source EAD file
 func (m *Meta) getSourcePath() string {
 	return fmt.Sprintf("%s/%s.xml", m.basePath, m.DatasetID)
+}
+
+// getDaoLinkErrors returns the error messages for each retrieved error and its unitId
+func (m *Meta) getDaoLinkErrors() (messages []string) {
+	for id, errMsg := range m.DaoErrorLinks {
+		messages = append(messages, fmt.Sprintf("Inventory %s => %s", id, errMsg))
+	}
+	return messages
 }

--- a/ikuzo/service/x/ead/oaipmh.go
+++ b/ikuzo/service/x/ead/oaipmh.go
@@ -38,7 +38,7 @@ func (e *EADHarvester) ProcessEadFromOai(r *oai.Response) {
 			Str("identifier", record.Header.Identifier).
 			Strs("set", record.Header.SetSpec).
 			Str("lastModified", record.Header.DateStamp).
-			Str("status", record.Header.Status).
+			Str("recordStatus", record.Header.Status).
 			Msg("ead file entry")
 
 		if err := e.processRecord(&record); err != nil {
@@ -113,7 +113,7 @@ func (m *MetsHarvester) ProcessMetsFromOai(r *oai.Response) {
 			Str("identifier", header.Identifier).
 			Strs("set", header.SetSpec).
 			Str("lastModified", header.DateStamp).
-			Str("status", header.Status).
+			Str("recordStatus", header.Status).
 			Msg("mets entry")
 
 		if err := m.processHeader(header); err != nil {

--- a/ikuzo/service/x/ead/task.go
+++ b/ikuzo/service/x/ead/task.go
@@ -130,7 +130,7 @@ func (t *Task) finishTask() {
 		Uint64("digitalObjects", t.Meta.DigitalObjects).
 		Bool("created", t.Meta.Created).
 		Uint64("metsRetrieveErrors", t.Meta.DaoErrors).
-		Strs("metsErrorLinks ", t.Meta.DaoErrorLinks).
+		Strs("metsErrorLinks ", t.Meta.getDaoLinkErrors()).
 		Uint64("fileSize", t.Meta.FileSize).
 		Msg("finished processing")
 


### PR DESCRIPTION
HUB-188 We should not use status as a string because that is mostly used as an int for logging HTTP status
HUB-188 Output the url param qf always as an object. We found a datatype mismatch in the Elastic field "qf" and "qf.dateRange" . The first type is stored as a keyword and the second is an object. This change serializes the qf parameter always as an object for the Elastic index.