### PR TITLE
Feature/v0.2.0/image proxy blacklisting support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added 
 
+- Support for blacklisting URIs and limiting caching to referrers in the image proxy service [[GH73]](https://github.com/delving/hub3/pull/73)
 - Create c level and Node from p element in dsc element and add every Cp field to the Odd in the created Clevel. [[GH-67]](https://github.com/delving/hub3/pull/67)
 - Sort fields in the fieldMap resource.NewFields because the map is always unordered. Store protobuf messages in resource and use pointers instead of values for protobuf field in FragmentGraph. [[GH-63]](https://github.com/delving/hub3/pull/63)
 - Update to v2 RAML API documentation [[GH-59]](https://github.com/delving/hub3/pull/59)

--- a/ikuzo/ikuzoctl/cmd/config/imageproxy.go
+++ b/ikuzo/ikuzoctl/cmd/config/imageproxy.go
@@ -25,6 +25,7 @@ type ImageProxy struct {
 	ProxyPrefix   string
 	Timeout       int
 	ProxyReferrer []string
+	BlackList     []string
 }
 
 func (ip *ImageProxy) AddOptions(cfg *Config) error {
@@ -37,6 +38,7 @@ func (ip *ImageProxy) AddOptions(cfg *Config) error {
 		imageproxy.SetProxyPrefix(ip.ProxyPrefix),
 		imageproxy.SetTimeout(ip.Timeout),
 		imageproxy.SetProxyReferrer(ip.ProxyReferrer),
+		imageproxy.SetBlackList(ip.BlackList),
 	)
 
 	if err != nil {

--- a/ikuzo/ikuzoctl/cmd/config/imageproxy.go
+++ b/ikuzo/ikuzoctl/cmd/config/imageproxy.go
@@ -20,10 +20,11 @@ import (
 )
 
 type ImageProxy struct {
-	Enabled     bool
-	CacheDir    string
-	ProxyPrefix string
-	Timeout     int
+	Enabled       bool
+	CacheDir      string
+	ProxyPrefix   string
+	Timeout       int
+	ProxyReferrer []string
 }
 
 func (ip *ImageProxy) AddOptions(cfg *Config) error {
@@ -35,6 +36,7 @@ func (ip *ImageProxy) AddOptions(cfg *Config) error {
 		imageproxy.SetCacheDir(ip.CacheDir),
 		imageproxy.SetProxyPrefix(ip.ProxyPrefix),
 		imageproxy.SetTimeout(ip.Timeout),
+		imageproxy.SetProxyReferrer(ip.ProxyReferrer),
 	)
 
 	if err != nil {


### PR DESCRIPTION
Added functionality to the image proxy:

* blacklist URIs for caching based on substrings
* limit caching to a configured set of referrers.