### PR TITLE
Refactor sparql support into its own service.

### DIFF
--- a/ikuzo/domain/stats.go
+++ b/ikuzo/domain/stats.go
@@ -1,0 +1,7 @@
+package domain
+
+// DataSetRevisions holds the type-frequency data for each revision for a given DataSet
+type DataSetRevisions struct {
+	Number      int `json:"revisionNumber"`
+	RecordCount int `json:"recordCount"`
+}

--- a/ikuzo/service/x/sparql/bank.go
+++ b/ikuzo/service/x/sparql/bank.go
@@ -1,0 +1,82 @@
+package sparql
+
+const queries = `
+# SPARQL queries that are loaded as a QueryBank
+
+# ask returns a boolean
+# tag: ask_subject
+ASK { <{{ .URI }}> ?p ?o }
+
+# tag: ask_predicate
+ASK { ?s <{{ .URI }}> ?o }
+
+# tag: ask_object
+ASK { ?s <{{ .URI }}> ?o }
+
+# tag: ask_query
+ASK { {{ .Query }} }
+
+# The DESCRIBE form returns a single result RDF graph containing RDF data about resources.
+# tag: describe
+DESCRIBE <{{.URI}}>
+
+# tag: countGraphPerSpec
+SELECT (count(?subject) as ?count)
+WHERE {
+  ?subject <http://schemas.delving.eu/nave/terms/datasetSpec> "{{.Spec}}"
+}
+LIMIT 1
+
+# tag: countRevisionsBySpec
+SELECT ?revision (COUNT(?revision) as ?rCount)
+WHERE
+{
+  ?subject <http://schemas.delving.eu/nave/terms/datasetSpec> "{{.Spec}}";
+		<http://schemas.delving.eu/nave/terms/specRevision> ?revision .
+}
+GROUP BY ?revision
+
+# tag: deleteAllGraphsBySpec
+DELETE {
+	GRAPH ?g {
+	?s ?p ?o .
+	}
+}
+WHERE {
+	GRAPH ?g {
+	?subject <http://schemas.delving.eu/nave/terms/datasetSpec> "{{.Spec}}".
+	}
+	GRAPH ?g {
+	?s ?p ?o .
+	}
+};
+
+# tag: deleteOrphanGraphsBySpec
+DELETE {
+	GRAPH ?g {
+	?s ?p ?o .
+	}
+}
+WHERE {
+	GRAPH ?g {
+	?subject <http://schemas.delving.eu/nave/terms/datasetSpec> "{{.Spec}}";
+		<http://schemas.delving.eu/nave/terms/specRevision> ?revision .
+		FILTER (?revision != {{.RevisionNumber}}).
+	}
+	GRAPH ?g {
+	?s ?p ?o .
+	}
+};
+
+# tag: countAllTriples
+SELECT (count(?s) as ?count)
+WHERE {
+  ?s ?p ?o .
+};
+
+# tag: harvestTriples
+SELECT *
+WHERE {
+  ?s ?p ?o .
+} LIMIT {{.Limit}} OFFSET {{.Offset}}
+`

--- a/ikuzo/service/x/sparql/datasets.go
+++ b/ikuzo/service/x/sparql/datasets.go
@@ -1,0 +1,44 @@
+package sparql
+
+import (
+	"context"
+	"log"
+)
+
+// DeleteAllGraphsBySpec issues an SPARQL Update query to delete all graphs for a DataSet from the triple store
+func (s *Service) DeleteAllGraphsBySpec(ctx context.Context, spec string) (bool, error) {
+	query, err := s.bank.Prepare("deleteAllGraphsBySpec", struct{ Spec string }{spec})
+	if err != nil {
+		log.Printf("Unable to build deleteAllGraphsBySpec query: %s", err)
+		return false, err
+	}
+
+	err = s.store.SparqlUpdate(ctx, query)
+	if err != nil {
+		log.Printf("Unable query endpoint: %s", err)
+		return false, err
+	}
+
+	return true, nil
+}
+
+// DeleteGraphsOrphansBySpec issues an SPARQL Update query to delete all orphaned graphs
+// for a DataSet from the triple store.
+func (s *Service) DeleteGraphsOrphansBySpec(ctx context.Context, spec string, revision int) (bool, error) {
+	query, err := s.bank.Prepare("deleteOrphanGraphsBySpec", struct {
+		Spec           string
+		RevisionNumber int
+	}{spec, revision})
+	if err != nil {
+		log.Printf("sparql: unable to build deleteOrphanGraphsBySpec query: %s", err)
+		return false, err
+	}
+
+	err = s.store.SparqlUpdate(ctx, query)
+	if err != nil {
+		log.Printf("sparql: unable query endpoint: %s", err)
+		return false, err
+	}
+
+	return true, nil
+}

--- a/ikuzo/service/x/sparql/options.go
+++ b/ikuzo/service/x/sparql/options.go
@@ -1,0 +1,27 @@
+package sparql
+
+import (
+	"bytes"
+
+	"github.com/knakk/sparql"
+)
+
+type Option func(*Service) error
+
+// SetCustomQueries allows custom Sparql Queries to be added to the sparql.Bank
+//
+// Each query must be preceded by a comment otherwise the query is silently ignored.
+func SetCustomQueries(queries string) Option {
+	return func(s *Service) error {
+		f := bytes.NewBufferString(queries)
+		return s.mergeBank(sparql.LoadBank(f))
+	}
+}
+
+// SetTripleStore sets the TripleStore implementation for the sparql.Service
+func SetTripleStore(store TripleStore) Option {
+	return func(s *Service) error {
+		s.store = store
+		return nil
+	}
+}

--- a/ikuzo/service/x/sparql/service.go
+++ b/ikuzo/service/x/sparql/service.go
@@ -1,0 +1,60 @@
+package sparql
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/knakk/sparql"
+)
+
+type TripleStore interface {
+	CreateDB(ctx context.Context, name string) error
+	DropDB(ctx context.Context, name string) error
+	SparqlUpdate(ctx context.Context, query string) error
+	SparqlQuery(ctx context.Context, query string) (sparql.Results, error)
+}
+
+type Service struct {
+	bank  sparql.Bank
+	store TripleStore
+}
+
+func NewService(options ...Option) (*Service, error) {
+	s := &Service{}
+
+	f := bytes.NewBufferString(queries)
+	s.bank = sparql.LoadBank(f)
+
+	// apply options
+	for _, option := range options {
+		if err := option(s); err != nil {
+			return nil, err
+		}
+	}
+
+	if s.store == nil {
+		return s, fmt.Errorf("sparql: TripleStore interface must have a concrete implementation")
+	}
+
+	return s, nil
+}
+
+// mergeBank overrides queries on the service query bank when they have the same key.
+func (s *Service) mergeBank(customBank sparql.Bank) error {
+	for k, v := range customBank {
+		s.bank[k] = v
+	}
+
+	return nil
+}
+
+// implement sparql proxy implementation
+func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+}
+
+// should connections be shutdown
+func (s *Service) Shutdown(ctx context.Context) error {
+	return nil
+}

--- a/ikuzo/service/x/sparql/service_test.go
+++ b/ikuzo/service/x/sparql/service_test.go
@@ -1,0 +1,60 @@
+package sparql
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/knakk/sparql"
+	"github.com/matryer/is"
+)
+
+// compile time check to see if full interface is implemented
+var _ TripleStore = (*mockTripleStore)(nil)
+
+type mockTripleStore struct{}
+
+func (m *mockTripleStore) CreateDB(ctx context.Context, name string) error      { return nil }
+func (m *mockTripleStore) DropDB(ctx context.Context, name string) error        { return nil }
+func (m *mockTripleStore) SparqlUpdate(ctx context.Context, query string) error { return nil }
+func (m *mockTripleStore) SparqlQuery(ctx context.Context, query string) (sparql.Results, error) {
+	return sparql.Results{}, nil
+}
+
+// nolint:gocritic
+func TestMergeBank(t *testing.T) {
+	is := is.New(t)
+
+	s, err := NewService(
+		SetTripleStore(&mockTripleStore{}),
+	)
+	is.NoErr(err)
+
+	queryCount := len(s.bank)
+	is.True(queryCount != 0)
+
+	const queries = `
+# Comments are ignored, except those tagging a query.
+
+# tag: my-query
+SELECT *
+WHERE {
+  ?s ?p ?o
+} LIMIT {{.Limit}} OFFSET {{.Offset}}
+
+# tag: describe
+DESCRIBE <{{.URI}}>
+`
+
+	f := bytes.NewBufferString(queries)
+	bank := sparql.LoadBank(f)
+
+	is.True(len(bank) == 2)
+
+	err = s.mergeBank(bank)
+	is.NoErr(err)
+
+	t.Logf("bank: %+v", s.bank)
+
+	is.Equal(queryCount+1, len(s.bank))
+}

--- a/ikuzo/service/x/sparql/stats.go
+++ b/ikuzo/service/x/sparql/stats.go
@@ -1,0 +1,81 @@
+package sparql
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/delving/hub3/ikuzo/domain"
+)
+
+// CountGraphsBySpec counts all the named graphs for a spec
+func (s *Service) CountGraphsBySpec(spec string) (int, error) {
+	query, err := s.bank.Prepare("countGraphPerSpec", struct{ Spec string }{spec})
+	if err != nil {
+		log.Printf("sparql: unable to build CountGraphsBySpec query: %s", err)
+		return 0, err
+	}
+
+	res, err := s.store.SparqlQuery(context.TODO(), query)
+	if err != nil {
+		log.Printf("sparql: unable query endpoint: %s", err)
+		return 0, err
+	}
+
+	countStr, ok := res.Bindings()["count"]
+	if !ok {
+		return 0, fmt.Errorf("sparql: unable to get count from result bindings: %#v", res.Bindings())
+	}
+
+	var count int
+
+	count, err = strconv.Atoi(countStr[0].String())
+	if err != nil {
+		return 0, fmt.Errorf("sparql: unable to convert count %s to integer", countStr)
+	}
+
+	return count, err
+}
+
+// CountRevisionsBySpec counts each revision available in the spec
+func (s *Service) CountRevisionsBySpec(spec string) ([]domain.DataSetRevisions, error) {
+	revisions := []domain.DataSetRevisions{}
+
+	query, err := s.bank.Prepare("countRevisionsBySpec", struct{ Spec string }{spec})
+	if err != nil {
+		log.Printf("Unable to build countRevisionsBySpec query: %s", err)
+		return revisions, err
+	}
+
+	res, err := s.store.SparqlQuery(context.TODO(), query)
+	if err != nil {
+		log.Printf("Unable query endpoint: %s", err)
+		return revisions, err
+	}
+
+	for _, v := range res.Solutions() {
+		revisionTerm, ok := v["revision"]
+		if !ok {
+			log.Printf("No revisions found for spec %s", spec)
+			return revisions, nil
+		}
+
+		revision, err := strconv.Atoi(revisionTerm.String())
+		if err != nil {
+			return revisions, fmt.Errorf("unable to convert %#v to integer", v["revision"])
+		}
+
+		revisionCount, err := strconv.Atoi(v["rCount"].String())
+		if err != nil {
+			return revisions, fmt.Errorf("unable to convert %#v to integer", v["rCount"])
+		}
+
+		revisions = append(revisions, domain.DataSetRevisions{
+			Number:      revision,
+			RecordCount: revisionCount,
+		})
+	}
+
+	return revisions, nil
+}


### PR DESCRIPTION
This is part of the process to phase out hub3/models package.