### PR TITLE
Update elasticsearch mapping and configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added 
 
+- Initial service for elasticsearch functionality. Better mapping management.  [[GH-78]](https://github.com/delving/hub3/pull/78)
 - Multitenancy support through organisationIDs  [[GH-77]](https://github.com/delving/hub3/pull/77)
 - Initial version of Time Revision Store  [[GH-76]](https://github.com/delving/hub3/pull/76)
 - Dedicated SPARQL service that can be used as a separate publisher [[GH-75]](https://github.com/delving/hub3/pull/75)

--- a/ikuzo/ikuzoctl/cmd/config/elasticsearch.go
+++ b/ikuzo/ikuzoctl/cmd/config/elasticsearch.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -73,6 +74,8 @@ type ElasticSearch struct {
 	FastHTTP bool
 	// OrphanWait is the duration in seconds that the orphanDelete will wait for the cluster to be in sync
 	OrphanWait int
+	// once makes sure that createmapping is only run once
+	once sync.Once
 	// UserName is the BasicAuth username
 	UserName string `json:"userName"`
 	// Password is the BasicAuth password
@@ -91,6 +94,10 @@ func (e *ElasticSearch) AddOptions(cfg *Config) error {
 	client, err := e.NewClient(&cfg.logger)
 	if err != nil {
 		return fmt.Errorf("unable to create elasticsearch.Client: %w", err)
+	}
+
+	if _, infoErr := client.Info(); infoErr != nil {
+		return fmt.Errorf("unable to connect to elasticsearch; %w", infoErr)
 	}
 
 	if e.Proxy {
@@ -143,7 +150,7 @@ func (e *ElasticSearch) AddOptions(cfg *Config) error {
 
 func (e *ElasticSearch) ResetAll(w http.ResponseWriter, r *http.Request) {
 	// reset elasticsearch
-	_, err := e.CreateDefaultMappings(e.client, true, true)
+	_, err := e.createDefaultMappings(e.client, true, true)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
@@ -155,6 +162,16 @@ func (e *ElasticSearch) ResetAll(w http.ResponseWriter, r *http.Request) {
 }
 
 func (e *ElasticSearch) CreateDefaultMappings(es *elasticsearch.Client, withAlias, withReset bool) ([]string, error) {
+	e.once.Do(func() {
+		if _, err := e.createDefaultMappings(es, withAlias, withReset); err != nil {
+			log.Error().Err(err).Msg("unable to create default mappings for elasticsearch")
+		}
+	})
+
+	return []string{}, nil
+}
+
+func (e *ElasticSearch) createDefaultMappings(es *elasticsearch.Client, withAlias, withReset bool) ([]string, error) {
 	mappings := map[string]func(shards, replicas int) string{}
 
 	for _, indexType := range e.IndexTypes {
@@ -205,6 +222,24 @@ func (e *ElasticSearch) CreateDefaultMappings(es *elasticsearch.Client, withAlia
 
 		if err != nil && !errors.Is(err, eshub.ErrIndexAlreadyCreated) {
 			return []string{}, err
+		}
+
+		if errors.Is(err, eshub.ErrIndexAlreadyCreated) {
+			if strings.HasSuffix(indexName, "v2") {
+				valid, err := eshub.IsMappingValid(es, createName)
+				if err != nil {
+					return []string{}, err
+				}
+
+				if !valid {
+					if err := eshub.MappingUpdate(es, createName, mapping.V2MappingUpdate()); err != nil {
+						log.Error().Err(err).Msg("unable to apply v2 mapping update")
+						return []string{}, err
+					}
+
+					log.Warn().Str("index", createName).Msg("applying elasticsearch mapping update")
+				}
+			}
 		}
 
 		indexNames = append(indexNames, createName)

--- a/ikuzo/service/x/search/es/docs.go
+++ b/ikuzo/service/x/search/es/docs.go
@@ -1,0 +1,1 @@
+package es

--- a/ikuzo/service/x/search/es/service.go
+++ b/ikuzo/service/x/search/es/service.go
@@ -1,0 +1,30 @@
+package es
+
+import (
+	"context"
+	"net/http"
+)
+
+type Option func(*Service) error
+
+type Service struct{}
+
+func NewService(options ...Option) (*Service, error) {
+	s := &Service{}
+
+	// apply options
+	for _, option := range options {
+		if err := option(s); err != nil {
+			return nil, err
+		}
+	}
+
+	return s, nil
+}
+
+func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+}
+
+func (s *Service) Shutdown(ctx context.Context) error {
+	return nil
+}

--- a/ikuzo/storage/x/elasticsearch/mapping.go
+++ b/ikuzo/storage/x/elasticsearch/mapping.go
@@ -1,0 +1,44 @@
+package elasticsearch
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/delving/hub3/ikuzo/storage/x/elasticsearch/mapping"
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/rs/zerolog/log"
+	"github.com/tidwall/gjson"
+)
+
+func IsMappingValid(es *elasticsearch.Client, indexName string) (bool, error) {
+	res, err := es.Indices.GetMapping(es.Indices.GetMapping.WithIndex(indexName))
+	if err != nil {
+		return false, err
+	}
+
+	defer res.Body.Close()
+
+	json := read(res.Body)
+
+	m := gjson.Parse(json).Map()
+
+	v, ok := m[indexName]
+	if !ok {
+		return false, nil
+	}
+
+	return mapping.ValidMapping(v.Get("mappings").Raw), nil
+}
+
+func MappingUpdate(es *elasticsearch.Client, indexName, esMapping string) error {
+	resp, err := es.Indices.PutMapping([]string{indexName}, strings.NewReader(esMapping))
+	if err != nil {
+		return fmt.Errorf("unable to update mapping; %w", err)
+	}
+
+	if resp.HasWarnings() {
+		log.Warn().Msgf("mapping update warnings: %#v", resp.Warnings())
+	}
+
+	return nil
+}

--- a/ikuzo/storage/x/elasticsearch/mapping/update.go
+++ b/ikuzo/storage/x/elasticsearch/mapping/update.go
@@ -25,8 +25,8 @@ import (
 // this should prevent changes to the mapping that are not reflected in the update.
 // this is needed for all mappings that have strict fields.
 const (
-	v2MappingSha       = "332a55b29c0b868d"
-	v2UpdateMappingSha = "9b20cec1c69f8b7b"
+	v2MappingSha       = "fb1d72134758dea3"
+	v2UpdateMappingSha = "b8d4f29ec1e660df"
 	fragmentMappingSha = "7607ca7737d17e4a"
 )
 
@@ -36,13 +36,22 @@ var keys = map[string]string{
 	fragmentMappingSha: fragmentMapping,
 }
 
-func ValidateMappings() (old, current string, ok bool) {
+func ValidMapping(mapping string) bool {
+	// TODO(kiivihal): Fix this currently the shape of the stored mapping is different from
+	// the one returned by elasticsearch
+	h := Hash(mapping)
+	// log.Debug().Str("hash", h).Str("mapping", mapping).Msg("requested mapping hash")
+	_, ok := keys[h]
+	return ok
+}
+
+func validateMappings() (old, current string, ok bool) {
 	return validate(keys)
 }
 
 func validate(keys map[string]string) (old, current string, ok bool) {
 	for old, mapping := range keys {
-		if current := hash(mapping); current != old {
+		if current := Hash(mapping); current != old {
 			return old, current, false
 		}
 	}
@@ -50,7 +59,7 @@ func validate(keys map[string]string) (old, current string, ok bool) {
 	return "", "", true
 }
 
-func hash(input string) string {
+func Hash(input string) string {
 	hash := xxhash.Checksum64([]byte(input))
 
 	return fmt.Sprintf("%016x", hash)

--- a/ikuzo/storage/x/elasticsearch/mapping/update_test.go
+++ b/ikuzo/storage/x/elasticsearch/mapping/update_test.go
@@ -111,7 +111,7 @@ func TestValidateMappings(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			gotOld, gotCurrent, gotOk := ValidateMappings()
+			gotOld, gotCurrent, gotOk := validateMappings()
 			if gotOld != tt.wantOld {
 				t.Errorf("ValidateMappings() gotOld = %v, want %v", gotOld, tt.wantOld)
 			}

--- a/ikuzo/storage/x/elasticsearch/mapping/v2.go
+++ b/ikuzo/storage/x/elasticsearch/mapping/v2.go
@@ -66,7 +66,10 @@ var v2Mapping = `{
 						"docType": {"type": "keyword"},
 						"namedGraphURI": {"type": "keyword"},
 						"entryURI": {"type": "keyword"},
-						"modified": {"type": "date"}
+						"modified": {"type": "date"},
+						"sourceID": {"type": "keyword"},
+						"sourcePath": {"type": "keyword"},
+						"groupID": {"type": "keyword"}
 					}
 				},
 				"protobuf": {
@@ -194,6 +197,14 @@ func V2MappingUpdate() string {
 // 'strict' on dynamic creating of new fields in the index.
 var v2MappingUpdate = `{
   "properties": {
+	"meta": {
+		"type": "object",
+		"properties": {
+			"sourceID": {"type": "keyword"},
+			"sourcePath": {"type": "keyword"},
+			"groupID": {"type": "keyword"}
+		}
+	},
     "tree": {
       "properties": {
         "physDesc": {"type": "keyword"},


### PR DESCRIPTION
By migrating more elasticsearch functionality to the services we are able to decouple the search implementation better from the rest of the code-base.