### PR TITLE
Feature/v0.2.1/oai-pmh-service refactor

### DIFF
--- a/ikuzo/service/x/oaipmh/oai/client.go
+++ b/ikuzo/service/x/oaipmh/oai/client.go
@@ -1,0 +1,173 @@
+package oaipmh
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Request represents a request URL and query string to an OAI-PMH service
+type Request struct {
+	BaseURL          string
+	Verb             string
+	MetadataPrefix   string
+	Set              string
+	From             string
+	Until            string
+	ResumptionToken  string
+	Identifier       string
+	completeListSize int
+}
+
+// NewRequest builds a Request from the query paramers of the http.Request
+//
+// This is used to build a server-side request. The client needs to build the
+// Request directly using the struct.
+func NewRequest(r *http.Request) Request {
+	baseURL := fmt.Sprintf("%s://%s%s", r.URL.Scheme, r.Host, r.URL.Path)
+	q := r.URL.Query()
+	req := Request{
+		Verb:            q.Get("verb"),
+		MetadataPrefix:  q.Get("metadataPrefix"),
+		Set:             q.Get("set"),
+		From:            q.Get("from"),
+		Until:           q.Get("until"),
+		Identifier:      q.Get("identifier"),
+		ResumptionToken: q.Get("resumptionToken"),
+		BaseURL:         baseURL,
+	}
+
+	return req
+}
+
+// GetFullURL represents the OAI Request in a string format
+func (request *Request) GetFullURL() string {
+	array := []string{}
+
+	add := func(name, value string) {
+		if value != "" {
+			array = append(array, name+"="+value)
+		}
+	}
+
+	add("verb", request.Verb)
+	add("set", request.Set)
+	add("metadataPrefix", request.MetadataPrefix)
+	add("resumptionToken", url.QueryEscape(request.ResumptionToken))
+	add("identifier", request.Identifier)
+	add("from", request.From)
+	add("until", request.Until)
+
+	URL := strings.Join([]string{request.BaseURL, "?", strings.Join(array, "&")}, "")
+
+	return URL
+}
+
+// HarvestIdentifiers arvest the identifiers of a complete OAI set
+// call the identifier callback function for each Header
+func (request *Request) HarvestIdentifiers(callback func(*Header)) {
+	request.Verb = "ListIdentifiers"
+	request.Harvest(func(resp *Response) {
+		headers := resp.ListIdentifiers.Headers
+		for _, header := range headers {
+			callback(&header)
+		}
+	})
+}
+
+// HarvestRecords harvest the identifiers of a complete OAI set
+// call the identifier callback function for each Header
+func (request *Request) HarvestRecords(callback func(*Record)) {
+	request.Verb = "ListRecords"
+	request.Harvest(func(resp *Response) {
+		records := resp.ListRecords.Records
+		for _, record := range records {
+			callback(&record)
+		}
+	})
+}
+
+// Harvest perform a harvest of a complete OAI set, or simply one request
+// call the batchCallback function argument with the OAI responses
+func (request *Request) Harvest(batchCallback func(*Response)) {
+	// Use Perform to get the OAI response
+	oaiResponse := request.Perform()
+
+	// Execute the callback function with the response
+	batchCallback(oaiResponse)
+
+	// Check for a resumptionToken
+	hasResumptionToken, resumptionToken, completeListSize := oaiResponse.GetResumptionToken()
+
+	// Harvest further if there is a resumption token
+	if hasResumptionToken == true {
+		request.Set = ""
+		request.MetadataPrefix = ""
+		request.From = ""
+		request.ResumptionToken = resumptionToken
+		request.completeListSize = completeListSize
+		request.Harvest(batchCallback)
+	}
+}
+
+// Perform an HTTP GET request using the OAI Requests fields
+// and return an OAI Response reference
+func (request *Request) Perform() (oaiResponse *Response) {
+
+	timeout := time.Duration(60 * time.Second)
+	client := http.Client{
+		Timeout: timeout,
+	}
+
+	err := retry(10, time.Second, func() error {
+
+		resp, err := client.Get(request.GetFullURL())
+		if err != nil {
+			return err
+		}
+
+		// Make sure the response body object will be closed after
+		// reading all the content body's data
+		defer resp.Body.Close()
+
+		s := resp.StatusCode
+		switch {
+		case s >= 500:
+			// Retry
+			return fmt.Errorf("server error: %v", s)
+		case s == 408:
+			// Retry
+			return fmt.Errorf("Timeout error: %v", s)
+		case s >= 400:
+			// Don't retry, it was client's fault
+			return stop{fmt.Errorf("client error: %v", s)}
+		default:
+			// Happy
+			// Read all the data
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return stop{err}
+			}
+
+			// Unmarshall all the data
+			err = xml.Unmarshal(body, &oaiResponse)
+			if err != nil {
+				return stop{err}
+			}
+
+			return nil
+		}
+
+	})
+	if err != nil {
+		// unable to harvest panic for now
+		log.Printf("problem url: %s", request.GetFullURL())
+		panic(err)
+	}
+	return
+}

--- a/ikuzo/service/x/oaipmh/oai/client_test.go
+++ b/ikuzo/service/x/oaipmh/oai/client_test.go
@@ -1,0 +1,79 @@
+package oaipmh
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestNewRequest(t *testing.T) {
+	type args struct {
+		r *http.Request
+	}
+
+	req := func(url string) *http.Request {
+		r, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			t.Fatalf("unable to build request: %s", err)
+		}
+
+		return r
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want Request
+	}{
+		{
+			"empty",
+			args{req("http://localhost:3000/api/oai-pmh/ead")},
+			Request{
+				BaseURL: "http://localhost:3000/api/oai-pmh/ead",
+			},
+		},
+		{
+			"full request",
+			args{
+				req(
+					"https://localhost:3000/api/oai-pmh/ead?verb=ListRecords" +
+						"&metadataPrefix=oai_dc&set=all&from=1970-01-01" +
+						"&until=2000-01-01",
+				)},
+			Request{
+				BaseURL:        "https://localhost:3000/api/oai-pmh/ead",
+				Set:            "all",
+				MetadataPrefix: "oai_dc",
+				Verb:           "ListRecords",
+				From:           "1970-01-01",
+				Until:          "2000-01-01",
+			},
+		},
+		{
+			"resumptionToken request",
+			args{
+				req(
+					"https://localhost:3000/api/oai-pmh/ead?verb=ListRecords" +
+						"&resumptionToken=123abc",
+				)},
+			Request{
+				BaseURL:         "https://localhost:3000/api/oai-pmh/ead",
+				Verb:            "ListRecords",
+				ResumptionToken: "123abc",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewRequest(tt.args.r)
+			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreUnexported(Request{})); diff != "" {
+				t.Errorf("NewRequest() %s = mismatch (-want +got):\n%s", tt.name, diff)
+			}
+		})
+	}
+}

--- a/ikuzo/service/x/oaipmh/oai/fs.go
+++ b/ikuzo/service/x/oaipmh/oai/fs.go
@@ -1,0 +1,1 @@
+package oaipmh

--- a/ikuzo/service/x/oaipmh/oai/handler.go
+++ b/ikuzo/service/x/oaipmh/oai/handler.go
@@ -1,0 +1,94 @@
+// Copyright © 2017 Delving B.V. <info@delving.eu>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package oaipmh
+
+import (
+	"github.com/kiivihal/goharvest/oai"
+)
+
+// ProcessVerb processes different OAI-PMH verbs
+func ProcessVerb(r *oai.Request) interface{} {
+	switch r.Verb {
+	case "Identify":
+		return renderIdentify(r)
+	case "ListMetadataFormats":
+		// TODO add getter from list of record definitions
+		formats := []oai.MetadataFormat{
+			oai.MetadataFormat{
+				MetadataPrefix:    "edm",
+				Schema:            "",
+				MetadataNamespace: "http://www.europeana.eu/schemas/edm/",
+			},
+		}
+
+		return oai.ListMetadataFormats{
+			MetadataFormat: formats,
+		}
+	case "ListSets":
+		return renderListSets(r)
+	case "ListIdentifiers":
+		return "identifiers"
+	case "ListRecords":
+		return "records"
+	case "GetRecord":
+		return "record"
+	default:
+		badVerb := oai.OAIError{
+			Code: "badVerb",
+			Message: `Value of the verb argument is not a legal OAI-PMH verb,
+			the verb argument is missing, or the verb argument is repeated.`,
+		}
+
+		return badVerb
+	}
+}
+
+// renderIdentify returns the identify response of the repository
+func renderIdentify(r *oai.Request) interface{} {
+	return oai.Identify{
+		//RepositoryName:    config.Config.OAIPMH.RepositoryName,
+		BaseURL:         r.BaseURL,
+		ProtocolVersion: "2.0",
+		//AdminEmail:        config.Config.OAIPMH.AdminEmails,
+		DeletedRecord:     "persistent",
+		EarliestDatestamp: "1970-01-01T00:00:00Z",
+		Granularity:       "YYYY-MM-DDThh:mm:ssZ",
+	}
+}
+
+// renderListSets returns a list of all the publicly available sets
+func renderListSets(r *oai.Request) interface{} {
+	sets := []oai.Set{}
+	// datasets, err := models.ListDataSets()
+	// if err != nil {
+	// logger.Errorln("Unable to retrieve datasets from the storage layer.")
+	// return sets
+	// }
+	// for _, ds := range datasets {
+	// if ds.Access.OAIPMH {
+	// sets = append(
+	// sets,
+	// oai.Set{
+	// SetSpec:        ds.Spec,
+	// SetName:        ds.Spec,                                //  todo change to name if it has one later
+	// SetDescription: oai.Description{Body: []byte(ds.Spec)}, //  TODO change to description from ds later.
+	// },
+	// )
+	// }
+	// }
+
+	return oai.ListSets{
+		Set: sets,
+	}
+}

--- a/ikuzo/service/x/oaipmh/oai/protocol.go
+++ b/ikuzo/service/x/oaipmh/oai/protocol.go
@@ -1,0 +1,285 @@
+package oaipmh
+
+// About is an optional and repeatable container to hold data about
+// the metadata part of the record.
+//
+// The contents of an about container must conform to an XML Schema.
+// Individual implementation communities may create XML Schema that define
+// specific uses for the contents of about containers. Two common uses of
+// about containers are:
+// - rights statements: some repositories may find it desirable to attach
+// terms of use to the metadata they make available through the OAI-PMH.
+// No specific set of XML tags for rights expression is defined by OAI-PMH,
+// but the about container is provided to allow for encapsulating
+// community-defined rights tags.
+// - provenance statements: One suggested use of the about container is
+// to indicate the provenance of a metadata record, e.g. whether it has
+// been harvested itself and if so from which repository, and when.
+// An XML Schema for such a provenance container, as well as some
+// supporting information is available from the accompanying
+// Implementation Guidelines document.
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#Record
+type About struct {
+	Body []byte `xml:",innerxml"`
+}
+
+// String returns the string representation
+func (ab About) String() string {
+	return string(ab.Body)
+}
+
+// Description is an extensible mechanism for communities to
+// describe their repositories.
+//
+// For example, the description container could be used to include
+// collection-level metadata in the response to the Identify request.
+// Implementation Guidelines are available to give directions with
+// this respect.
+// Each description container must be accompanied by the URL of an
+// XML schema describing the structure of the description container.
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#Identify
+//
+type Description struct {
+	Body []byte `xml:",innerxml"`
+}
+
+// String returns the string representation
+func (ab Description) String() string {
+	return string(ab.Body)
+}
+
+// Error represents an OAI error
+//
+// In event of an error or exception condition, repositories must
+// indicate OAI-PMH errors, distinguished from HTTP Status-Codes,
+// by including one or more error elements in the response.
+// While one error element is sufficient to indicate the presence
+// of the error or exception condition, repositories should report
+// all errors or exceptions that arise from processing the request.
+// Each error element must have a code attribute that must be from the
+// following table; each error element may also have a free text string
+// value to provide information about the error that is useful to a human
+// reader. These strings are not defined by the OAI-PMH.
+//
+// Error Codes
+// - badArgument	The request includes illegal arguments, is missing
+// required arguments, includes a repeated argument, or values for arguments
+// have an illegal syntax.
+// - badResumptionToken	The value of the resumptionToken argument is
+// invalid or expired.
+// - badVerb	Value of the verb argument is not a legal OAI-PMH verb, the
+// verb argument is missing, or the verb argument is repeated.
+// - cannotDisseminateFormat	The metadata format identified by the value
+// given for the metadataPrefix argument is not supported by the item or by
+// the repository.
+// - idDoesNotExist	The value of the identifier argument is unknown or illegal
+//  in this repository.
+// - noRecordsMatch	The combination of the values of the from, until, set and
+//  metadataPrefix arguments results in an empty list.
+// - noMetadataFormats	There are no metadata formats available for the
+//  specified item.
+// - noSetHierarchy	The repository does not support sets.
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#ErrorConditions
+//
+type Error struct {
+	Code    string `xml:"code,attr"`
+	Message string `xml:",chardata"`
+}
+
+// MetadataFormat is a metadata format available from a repository
+//
+// It contains:
+// 1. The metadataPrefix - a string to specify the metadata format in OAI-PMH
+// requests issued to the repository. metadataPrefix consists of any valid URI
+//  unreserved characters. metadataPrefix arguments are used in ListRecords,
+//  ListIdentifiers, and GetRecord requests to retrieve records, or the headers
+//   of records that include metadata in the format specified by the
+//    metadataPrefix;
+// 2. The metadata schema URL - the URL of an XML schema to test validity of
+// metadata expressed according to the format;
+// 3. The XML namespace URI that is a global identifier of the metadata format.
+//  (http://www.w3.org/TR/1999/REC-xml-names-19990114/Overview.html)
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#MetadataNamespaces
+//
+type MetadataFormat struct {
+	MetadataPrefix    string `xml:"metadataPrefix"`
+	Schema            string `xml:"schema"`
+	MetadataNamespace string `xml:"metadataNamespace"`
+}
+
+// Header contains the unique identifier of the item and properties necessary
+// for selective harvesting.
+//
+// The header consists of the following parts:
+// - the unique identifier -- the unique identifier of an item in a repository;
+// - the datestamp -- the date of creation, modification or deletion of the
+// record for the purpose of selective harvesting.
+// - zero or more setSpec elements -- the set membership of the item for the
+// purpose of selective harvesting.
+// - an optional status attribute with a value of deleted indicates the withdrawal
+// of availability of the specified metadata format for the item, dependent on
+// the repository support for deletions.
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#Record
+type Header struct {
+	Identifier string   `xml:"identifier"`
+	DateStamp  string   `xml:"datestamp"`
+	SetSpec    []string `xml:"setSpec"`
+	Status     string   `xml:"status,attr"`
+}
+
+// Identify is a verb used to retrieve information about a repository.
+//
+// Some of the information returned is required as part of the OAI-PMH.
+// Repositories may also employ the Identify verb to return additional
+// descriptive information.
+// The response must include one instance of the following elements:
+// - repositoryName : a human readable name for the repository;
+// - baseURL : the base URL of the repository;
+// - protocolVersion : the version of the OAI-PMH supported by the repository;
+// - earliestDatestamp : a UTCdatetime that is the guaranteed lower limit
+// of all datestamps recording changes, modifications, or deletions in the
+// repository. A repository must not use datestamps lower than the one
+// specified by the content of the earliestDatestamp element. earliestDatestamp
+// must be expressed at the finest granularity supported by the repository.
+// - deletedRecord : the manner in which the repository supports the notion
+// of deleted records. Legitimate values are no ; transient ; persistent
+// with meanings defined in the section on deletion.
+// - granularity: the finest harvesting granularity supported by the repository.
+// The legitimate values are YYYY-MM-DD and YYYY-MM-DDThh:mm:ssZ with meanings
+// as defined in ISO8601.
+//
+// The response must include one or more instances of the following element:
+// - adminEmail : the e-mail address of an administrator of the repository.
+//
+// The response may include multiple instances of the following optional
+// elements:
+//
+// - compression : a compression encoding supported by the repository.
+// The recommended values are those defined for the Content-Encoding header
+// in Section 14.11 of RFC 2616 describing HTTP 1.1. A compression element
+// should not be included for the identity encoding, which is implied.
+// - description : an extensible mechanism for communities to describe their
+// repositories. For example, the description container could be used to
+// include collection-level metadata in the response to the Identify request.
+// Implementation Guidelines are available to give directions with this respect.
+// Each description container must be accompanied by the URL of an XML schema
+// describing the structure of the description container.
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#Identify
+type Identify struct {
+	// must
+	RepositoryName    string   `xml:"repositoryName" json:"repositoryName"`
+	BaseURL           string   `xml:"baseURL" json:"baseURL"`
+	ProtocolVersion   string   `xml:"protocolVersion" json:"protocolVersion"`
+	EarliestDatestamp string   `xml:"earliestDatestamp" json:"earliestDatestamp"`
+	DeletedRecord     string   `xml:"deletedRecord" json:"deletedRecord"`
+	Granularity       string   `xml:"granularity" json:"granularity"`
+	AdminEmail        []string `xml:"adminEmail" json:"adminEmail"`
+
+	// may
+	Description []Description `xml:"description" json:"description"`
+}
+
+// Metadata is a single manifestation of the metadata from an item.
+//
+// The OAI-PMH supports items with multiple manifestations (formats)
+// of metadata.
+// At a minimum, repositories must be able to return records with metadata
+// expressed in the Dublin Core format, without any qualification. Optionally,
+// a repository may also disseminate other formats of metadata.
+// The specific metadata format of the record to be disseminated is specified
+// by means of an argument
+// -- the metadataPrefix
+// -- in the GetRecord or ListRecords request that produces the record.
+// The ListMetadataFormats request returns the list of all metadata formats
+// available from a repository, or for a specific item (which can be specified
+// as an argument to the ListMetadataFormats request).
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#Record
+type Metadata struct {
+	Body []byte `xml:",innerxml"`
+}
+
+// GoString returns the body as a string
+func (md Metadata) String() string {
+	return string(md.Body)
+}
+
+// Record is metadata expressed in a single format.
+//
+// A record is returned in an XML-encoded byte stream in response to an OAI-PMH
+// request for metadata from an item.
+// A record is identified unambiguously by the combination of the unique
+// identifier of the item from which the record is available, the metadataPrefix
+// identifying the metadata format of the record, and the datestamp of
+// the record.
+// The XML-encoding of records is organized into the following parts:
+// header, metadata, about
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#Record
+type Record struct {
+	Header   Header   `xml:"header"`
+	Metadata Metadata `xml:"metadata"`
+	About    About    `xml:"about"`
+}
+
+// ResumptionToken is a token that manages the flow control during harvesting.
+//
+// The following optional attributes may be included as part of the
+// resumptionToken element along with the resumptionToken itself:
+//
+// - expirationDate -- a UTCdatetime indicating when the resumptionToken ceases
+// to be valid.
+// - completeListSize -- an integer indicating the cardinality of the complete
+// list (i.e., the sum of the cardinalities of the incomplete lists). Because
+// there may be changes in a repository during a list request sequence, as
+// described under Idempotency of resumptionTokens, the value of completeListSize
+// may be only an estimate of the actual cardinality of the complete list and
+// may be revised during the list request sequence.
+// - cursor -- a count of the number of elements of the complete list thus far
+// returned (i.e. cursor starts at 0).
+
+// https://www.openarchives.org/OAI/openarchivesprotocol.html#FlowControl
+type ResumptionToken struct {
+	Token            string `xml:",chardata" json:"token"`
+	CompleteListSize int    `xml:"completeListSize,attr" json:"completeListSize"`
+	ExperationDate   string `xml:"experationDate" json:"experationDate"`
+}
+
+// Set is an optional construct for grouping items for the purpose of
+// selective harvesting.
+//
+// Repositories may organize items into sets. Set organization may be
+// flat, i.e. a simple list, or hierarchical.
+// Multiple hierarchies with distinct, independent top-level nodes are allowed.
+// Hierarchical organization of sets is expressed in the syntax of the setSpec
+// parameter as described below.
+// When a repository defines a set organization it must include set membership
+// information in the headers of items returned in response to the
+// ListIdentifiers, ListRecords and GetRecord requests.
+//
+// A Set has:
+// - setSpec -- a colon [:] separated list indicating the path from the root
+// of the set hierarchy to the respective node. Each element in the list is a
+// string consisting of any valid URI unreserved characters, which must not
+// contain any colons [:]. Since a setSpec forms a unique identifier for the
+// set within the repository, it must be unique for each set. Flat set
+// organizations have only sets with setSpec that do not contain any colons [:].
+// - setName -- a short human-readable string naming the set.
+// - setDescription -- an optional and repeatable container that may hold
+// community-specific XML-encoded data about the set; the accompanying
+// Implementation Guidelines document provides suggestions regarding the
+// usage of this container.
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#Set
+//
+type Set struct {
+	SetSpec        string      `xml:"setSpec"`
+	SetName        string      `xml:"setName"`
+	SetDescription Description `xml:"setDescription"`
+}

--- a/ikuzo/service/x/oaipmh/oai/response.go
+++ b/ikuzo/service/x/oaipmh/oai/response.go
@@ -1,0 +1,159 @@
+package oaipmh
+
+// ListMetadataFormats holds the formats received from server
+//
+// OAI-PMH supports the dissemination of records in multiple metadata
+// formats from a repository.
+// The ListMetadataFormats request returns the list of all metadata
+// formats available from a repository
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#MetadataNamespaces
+//
+type ListMetadataFormats struct {
+	MetadataFormat []MetadataFormat `xml:"metadataFormat"`
+}
+
+// ListIdentifiers is an abbreviated verb form of ListRecords, retrieving only
+// headers rather than records.
+//
+// Optional arguments permit selective harvesting of headers based on set
+// membership and/or datestamp.
+//
+// Depending on the repository's support for deletions, a returned header
+// may have a status attribute of "deleted" if a record matching the arguments
+//
+// specified in the request has been deleted.
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#ListIdentifiers
+//
+type ListIdentifiers struct {
+	Headers         []Header        `xml:"header"`
+	ResumptionToken ResumptionToken `xml:"resumptionToken"`
+}
+
+// GetRecord is used to retrieve an individual metadata record from a repository.
+//
+// Required arguments specify the identifier of the item from which the record
+// is requested and the format of the metadata that should be included in the
+// record. Depending on the level at which a repository tracks deletions, a
+// header with a "deleted" value for the status attribute may be returned,
+// in case the metadata format specified by the metadataPrefix is no longer
+// available from the repository or from the specified item.
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#GetRecord
+//
+type GetRecord struct {
+	Record Record `xml:"record"`
+}
+
+// ListRecords is a verb used to harvest records from a repository.
+//
+// Optional arguments permit selective harvesting of records based on set
+// membership and/or datestamp. Depending on the repository's support for
+// deletions, a returned header may have a status attribute of "deleted"
+// if a record matching the arguments specified in the request has been deleted.
+// No metadata will be present for records with deleted status.
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#FlowControl
+type ListRecords struct {
+	Records         []Record        `xml:"record"`
+	ResumptionToken ResumptionToken `xml:"resumptionToken"`
+}
+
+// ListSets represents a list of Sets
+//
+//  http://www.openarchives.org/OAI/openarchivesprotocol.html#Set
+//
+type ListSets struct {
+	Set []Set `xml:"set"`
+}
+
+// Response encapsulates the information from a harvest request
+//
+// All responses to OAI-PMH requests must be well-formed XML instance documents.
+// Encoding of the XML must use the UTF-8 representation of Unicode. Character
+// references, rather than entity references, must be used. Character references
+// allow XML responses to be treated as stand-alone documents that can be
+// manipulated without dependency on entity declarations external to the document.
+//
+// The XML data for all responses to OAI-PMH requests must validate against the
+// XML Schema shown at the end of this section . As can be seen from that schema,
+// responses to OAI-PMH requests have the following common markup:
+//
+// (ignored) The first tag output is an XML declaration where the version is
+// always 1.0 and the encoding is always UTF-8, eg: <?xml version="1.0" encoding="UTF-8" ?>
+// (ignored) The remaining content is enclosed in a root element with the name OAI-PMH.
+//
+// For all responses, the first two children of the root element are:
+// - responseDate -- a UTCdatetime indicating the time and date that the
+// response was sent. This must be expressed in UTC
+// - request -- indicating the protocol request that generated this response.
+//
+// The third child of the root element is either:
+// - error -- an element that must be used in case of an error or exception condition;
+// - (Identify, ListMetadataFormats, ListSets, GetRecord, ListIdentifiers,
+// ListRecords) an element with the same name as the verb of the respective
+// OAI-PMH request.
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#XMLResponse
+//
+type Response struct {
+	ResponseDate string      `xml:"responseDate"`
+	Request      RequestNode `xml:"request"`
+	Error        Error       `xml:"error"`
+
+	Identify            Identify            `xml:"Identify"`
+	ListMetadataFormats ListMetadataFormats `xml:"ListMetadataFormats"`
+	ListSets            ListSets            `xml:"ListSets"`
+	GetRecord           GetRecord           `xml:"GetRecord"`
+	ListIdentifiers     ListIdentifiers     `xml:"ListIdentifiers"`
+	ListRecords         ListRecords         `xml:"ListRecords"`
+}
+
+// RequestNode is indicating the protocol request that generated this response.
+//
+// The rules for generating the request element are as follows:
+// 1. The content of the request element must always be the base URL of the protocol request;
+// 2. The only valid attributes for the request element are the keys of the key=value pairs of protocol request. The attribute values must be the corresponding values of those key=value pairs;
+// 3. In cases where the request that generated this response did not result in an error or exception condition, the attributes and attribute values of the request element must match the key=value pairs of the protocol request;
+// 4. In cases where the request that generated this response resulted in a badVerb or badArgument error condition, the repository must return the base URL of the protocol request only. Attributes must not be provided in these cases.
+//
+// http://www.openarchives.org/OAI/openarchivesprotocol.html#XMLResponse
+//
+type RequestNode struct {
+	Verb           string `xml:"verb,attr"`
+	Set            string `xml:"set,attr"`
+	MetadataPrefix string `xml:"metadataPrefix,attr"`
+}
+
+// HasResumptionToken determines if the request has or not a ResumptionToken
+func (resp *Response) HasResumptionToken() bool {
+	return resp.ListIdentifiers.ResumptionToken.Token != "" || resp.ListRecords.ResumptionToken.Token != ""
+}
+
+// ResumptionToken determine the resumption token in this Response
+func (resp *Response) GetResumptionToken() (hasResumptionToken bool, resumptionToken string, completeListSize int) {
+	if resp == nil {
+		return
+	}
+
+	// First attempt to obtain a resumption token from a ListIdentifiers response
+	resumptionToken = resp.ListIdentifiers.ResumptionToken.Token
+
+	if resumptionToken != "" {
+		completeListSize = resp.ListIdentifiers.ResumptionToken.CompleteListSize
+	}
+
+	// Then attempt to obtain a resumption token from a ListRecords response
+	if resumptionToken == "" {
+		resumptionToken = resp.ListRecords.ResumptionToken.Token
+		completeListSize = resp.ListRecords.ResumptionToken.CompleteListSize
+	}
+
+	// If a non-empty resumption token turned up it can safely inferred that...
+	if resumptionToken != "" {
+		hasResumptionToken = true
+	}
+
+	return
+}

--- a/ikuzo/service/x/oaipmh/oai/retry.go
+++ b/ikuzo/service/x/oaipmh/oai/retry.go
@@ -1,0 +1,35 @@
+package oaipmh
+
+import (
+	"math/rand"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func retry(attempts int, sleep time.Duration, f func() error) error {
+	if err := f(); err != nil {
+		if s, ok := err.(stop); ok {
+			// Return the original error for later checking
+			return s.error
+		}
+
+		if attempts--; attempts > 0 {
+			// Add some randomness to prevent creating a Thundering Herd
+			jitter := time.Duration(rand.Int63n(int64(sleep)))
+			sleep = sleep + jitter/2
+
+			time.Sleep(sleep)
+			return retry(attempts, 2*sleep, f)
+		}
+		return err
+	}
+
+	return nil
+}
+
+type stop struct {
+	error
+}

--- a/ikuzo/service/x/oaipmh/oai/server.go
+++ b/ikuzo/service/x/oaipmh/oai/server.go
@@ -1,0 +1,152 @@
+package oaipmh
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/render"
+)
+
+type ServerOption func(*Server) error
+
+type RepoStore interface {
+	ListRepos(ctx context.Context) ([]Repo, error)
+	GetRepo(ctx context.Context, repo string) (Repo, error)
+}
+
+type Server struct {
+	repos       RepoStore
+	routePrefix string
+}
+
+type store struct {
+	path string
+}
+
+func NewFsRepoStore(path string) (RepoStore, error) {
+	s := store{path: path}
+	if err := os.MkdirAll(s.path, os.ModePerm); err != nil {
+		return s, fmt.Errorf("unable to create OAI-PMH fs store; %w", err)
+	}
+
+	return s, nil
+}
+
+func (s store) GetRepo(ctx context.Context, repo string) (Repo, error) {
+	return Repo{}, fmt.Errorf("implement me")
+}
+
+func (s store) ListRepos(ctx context.Context) ([]Repo, error) {
+	var repos []Repo
+
+	files, err := ioutil.ReadDir(s.path)
+	if err != nil {
+		return repos, err
+	}
+
+	for _, f := range files {
+		if _, err := os.Stat(filepath.Join(s.path, f.Name(), "identify.json")); os.IsNotExist(err) {
+			continue
+		}
+
+		repos = append(repos, Repo{Name: f.Name()})
+	}
+
+	return repos, nil
+}
+
+type Repo struct {
+	Name  string
+	Links map[string]string
+}
+
+func NewServer(options ...ServerOption) (*Server, error) {
+	s := &Server{}
+
+	// apply options
+	for _, option := range options {
+		if err := option(s); err != nil {
+			return nil, err
+		}
+	}
+
+	if s.repos == nil {
+		return s, fmt.Errorf("empty ServerStore is not allowed")
+	}
+
+	return s, nil
+}
+
+func (s *Server) handleListRepos() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		basePath := r.URL.Path
+
+		repos, err := s.repos.ListRepos(r.Context())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		resp := make([]Repo, len(repos))
+
+		for idx, repo := range repos {
+			repo.Links = make(map[string]string)
+			repo.Links["oai-pmh"] = filepath.Join(basePath, repo.Name)
+			resp[idx] = repo
+		}
+
+		render.JSON(w, r, resp)
+	}
+}
+
+func (s *Server) handleOaiPmhRequest() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// repo := chi.URLParam(r, "repo")
+
+		req := NewRequest(r)
+		render.JSON(w, r, req)
+	}
+}
+
+func (s *Server) Routes(routePrefix string) func(router chi.Router) {
+	if routePrefix == "" {
+		routePrefix = "/"
+	}
+
+	return func(router chi.Router) {
+		router.Get(routePrefix, s.handleListRepos())
+
+		if !strings.HasSuffix(routePrefix, "/") {
+			routePrefix += "/"
+		}
+
+		router.Get(routePrefix+"{repo}", s.handleOaiPmhRequest())
+	}
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
+	// closure to setup chi.Router
+	router := chi.NewRouter()
+	s.Routes("")(router)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		router.ServeHTTP(w, r)
+	}
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func SetServerStore(store RepoStore) ServerOption {
+	return func(s *Server) error {
+		s.repos = store
+		return nil
+	}
+}

--- a/ikuzo/service/x/oaipmh/pmh/client.go
+++ b/ikuzo/service/x/oaipmh/pmh/client.go
@@ -1,0 +1,39 @@
+package pmh
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Client
+type Client struct {
+
+	// baseURL is the target URL for the OAI-PMH repository.
+	// All query params are ignored and reset
+	baseURL *url.URL
+
+	// HTTPClient is the default http.Client with 60 second timeout.
+	// The timeout can be increased by providing your own http.Client
+	HTTPClient http.Client
+}
+
+func NewClient(endpoint string) (Client, error) {
+	client := http.Client{
+		Timeout: 60 * time.Second,
+	}
+
+	u, err := url.ParseRequestURI(endpoint)
+	if err != nil {
+		return Client{}, err
+	}
+
+	return Client{
+		baseURL:    u,
+		HTTPClient: client,
+	}, nil
+}
+
+// func (c Client) Identify() (Identify, error) {
+
+// }

--- a/ikuzo/service/x/oaipmh/pmh/client_test.go
+++ b/ikuzo/service/x/oaipmh/pmh/client_test.go
@@ -1,0 +1,32 @@
+package pmh
+
+import (
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+// nolint:gocritic
+func TestClient(t *testing.T) {
+	testURL := "http://localhost:8000/api/oai-pmh?"
+
+	t.Run("setting up client", func(t *testing.T) {
+		is := is.New(t)
+
+		c, err := NewClient(testURL)
+		is.NoErr(err)
+		is.Equal(c.baseURL.Path, "/api/oai-pmh")
+
+		is.True(c.HTTPClient.Timeout == 60*time.Second) // default timeout should be sixty seconds
+	})
+
+	// t.Run("test identify", func(t *testing.T) {
+	// is := is.New(t)
+	// c := NewClient(testURL)
+
+	// resp, err := c.Identify()
+	// is.NoErr(err)
+
+	// })
+}

--- a/ikuzo/service/x/oaipmh/pmh/docs.go
+++ b/ikuzo/service/x/oaipmh/pmh/docs.go
@@ -1,0 +1,5 @@
+// Package  provides a client and server implementation for the OAI-PMH v2.0
+// Protocol.
+//
+// The full specification can be found here: https://www.openarchives.org/OAI/openarchivesprotocol.html
+package pmh


### PR DESCRIPTION
The goal of this pull-request is to provide better client and server implementation for the OAI-PMH v2.0.

The server should have different implementations based on a shared interface. The default FS implementation should be able to be used as a stand-alone implementation to allow for easy publication of data.