### PR TITLE
Added config option for DigitalObjectPrefix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - history of changes: see https://github.com/delving/hub3/compare/v0.2.0...master
 
+### Added 
+ 
+- Config option to store records generated from METS files in dedicated index [[GH-83]](https://github.com/delving/hub3/pull/83)
+
 ## v0.2.0 (2021-03-10)
 
 - history of changes: see https://github.com/delving/hub3/compare/v0.1.10...v0.2.0

--- a/config/config.go
+++ b/config/config.go
@@ -82,30 +82,31 @@ type PostHook struct {
 // ElasticSearch holds all the configuration values
 // It is bound by Viper.
 type ElasticSearch struct {
-	Urls               []string `json:"urls"`
-	Enabled            bool     `json:"enabled"`
-	IndexName          string   `json:"indexName"`
-	Proxy              bool     `json:"proxy"`
-	Fragments          bool     `json:"fragments"`
-	IndexV1            bool     `json:"indexV1"` // exclusive with v2 indexing
-	EnableTrace        bool     `json:"enableTrace"`
-	EnableInfo         bool     `json:"enableInfo"`
-	SpecKey            string   `json:"specKey"`
-	RevisionKey        string   `json:"revisionKey"`
-	OrgIDKey           string   `json:"orgIDKey"`
-	UserName           string   `json:"userName"`
-	Password           string   `json:"password"`
-	FacetSize          int      `json:"facetSize"`
-	MinimumShouldMatch string   `json:"minimumShouldMatch"`
-	Workers            int      `json:"workers"`
-	Shards             int      `json:"shards"`
-	Replicas           int      `json:"replicas"`
-	RequestTimeout     int      `json:"requestTimeout"`
-	EnableSearchAfter  bool     `json:"enableSearchAfter"`
-	TrackTotalHits     bool     `json:"trackTotalHits"`
-	IndexTypes         []string `json:"indexTypes"`
-	MaxTreeSize        int      `json:"maxTreeSize"`
-	OrphanWait         int      `json:"orphanWait"`
+	Urls                []string `json:"urls"`
+	Enabled             bool     `json:"enabled"`
+	IndexName           string   `json:"indexName"`
+	DigitalObjectSuffix string   `json:"digitalObjectSuffix"`
+	Proxy               bool     `json:"proxy"`
+	Fragments           bool     `json:"fragments"`
+	IndexV1             bool     `json:"indexV1"` // exclusive with v2 indexing
+	EnableTrace         bool     `json:"enableTrace"`
+	EnableInfo          bool     `json:"enableInfo"`
+	SpecKey             string   `json:"specKey"`
+	RevisionKey         string   `json:"revisionKey"`
+	OrgIDKey            string   `json:"orgIDKey"`
+	UserName            string   `json:"userName"`
+	Password            string   `json:"password"`
+	FacetSize           int      `json:"facetSize"`
+	MinimumShouldMatch  string   `json:"minimumShouldMatch"`
+	Workers             int      `json:"workers"`
+	Shards              int      `json:"shards"`
+	Replicas            int      `json:"replicas"`
+	RequestTimeout      int      `json:"requestTimeout"`
+	EnableSearchAfter   bool     `json:"enableSearchAfter"`
+	TrackTotalHits      bool     `json:"trackTotalHits"`
+	IndexTypes          []string `json:"indexTypes"`
+	MaxTreeSize         int      `json:"maxTreeSize"`
+	OrphanWait          int      `json:"orphanWait"`
 }
 
 // FragmentIndexName returns the name of the Fragment index.
@@ -126,6 +127,14 @@ func (es *ElasticSearch) GetIndexName() string {
 
 func (es *ElasticSearch) GetV1IndexName() string {
 	return strings.ToLower(es.IndexName) + "v1"
+}
+
+func (es *ElasticSearch) GetDigitalObjectIndexName() string {
+	if es.DigitalObjectSuffix == "" {
+		return es.GetIndexName()
+	}
+
+	return strings.ToLower(es.IndexName) + "v2-" + strings.ToLower(es.DigitalObjectSuffix)
 }
 
 // Logging holds all the logging and path configuration

--- a/hub3.toml
+++ b/hub3.toml
@@ -1,5 +1,5 @@
 # The default orgId (deprecated)
-orgId = "hub3" 
+orgId = "hub3"
 # the default hub3 clusterID
 hub3ID = "hub3"
 # the url to the remote dataNode. When emtpy the current node is started in dataNode mode
@@ -9,10 +9,10 @@ dataNodeURL = ""
 domains = ["localhost:3000"]
 default = true
 
-[org.NL-HaNA]
+[org.hub3]
 domains = ["localhost:3001"]
-customID = "NL-HaNA"
-default = false
+customID = "hub3"
+default = true
 
 [http]
 # all the configuration for the http sub-command
@@ -48,6 +48,8 @@ metrics = true
 urls = ["http://localhost:9200"]
 # the name of the index. If empty it is the name of the OrgId
 indexName = "hub3"
+# if non-empty digital objects will be indexed in a dedicated v2 index
+digitalObjectSuffix = "scans"
 # if _mapping and _search proxies should be enabled
 proxy = true 
 # Store fragments 
@@ -81,7 +83,7 @@ shards = 1
 # replicas configuration for rdf and fragments index
 replicas = 0
 # indexTypes enabled types for the bulk index service
-indexTypes = ["v1", "v2"]
+indexTypes = ["v2"]
 # maxTreeSize is the maximum size of the number of nodes in the tree navigation API
 maxTreeSize = 251
 # orphanWait is the time in seconds that the goroutine waits for the cluster to be in sync before sending delete query
@@ -215,7 +217,7 @@ singleEndpoint = "NL-.*"
 cacheDir = "/tmp/ead"
 metrics = true
 workers = 1
-processDigital = false
+processDigital = true
 
 searchURL = ""
 genreFormDefault = "other/unknown"

--- a/hub3/ead/dao.go
+++ b/hub3/ead/dao.go
@@ -130,6 +130,8 @@ func (c *DaoClient) PublishFindingAid(cfg *DaoConfig) error {
 			return err
 		}
 
+		m.IndexName = config.Config.ElasticSearch.GetDigitalObjectIndexName()
+
 		if c.bi != nil {
 			c.bi.Publish(context.Background(), m)
 		}
@@ -145,6 +147,8 @@ func (c *DaoClient) PublishFindingAid(cfg *DaoConfig) error {
 	if err != nil {
 		return err
 	}
+
+	m.IndexName = config.Config.ElasticSearch.GetDigitalObjectIndexName()
 
 	if c.bi != nil {
 		c.bi.Publish(context.Background(), m)

--- a/hub3/models/dataset.go
+++ b/hub3/models/dataset.go
@@ -657,6 +657,10 @@ func (ds DataSet) deleteAllIndexRecords(ctx context.Context, wp *wp.WorkerPool) 
 		}
 	}
 
+	if c.Config.ElasticSearch.DigitalObjectSuffix != "" {
+		indices = append(indices, c.Config.ElasticSearch.GetDigitalObjectIndexName())
+	}
+
 	res, err := index.ESClient().DeleteByQuery().
 		Index(indices...).
 		Query(q).

--- a/ikuzo/ikuzoctl/cmd/config/elasticsearch.go
+++ b/ikuzo/ikuzoctl/cmd/config/elasticsearch.go
@@ -60,6 +60,8 @@ type ElasticSearch struct {
 	is *index.Service
 	// base of the index aliases
 	IndexName string
+	// if non-empty digital objects will be indexed in a dedicated v2 index
+	DigitalObjectSuffix string
 	// number of shards. default 1
 	Shards int
 	// number of replicas. default 0
@@ -185,6 +187,10 @@ func (e *ElasticSearch) createDefaultMappings(es *elasticsearch.Client, withAlia
 		default:
 			log.Warn().Msgf("ignoring unknown indexType %s during mapping creation", indexType)
 		}
+	}
+
+	if e.DigitalObjectSuffix != "" {
+		mappings[fmt.Sprintf("%sv2-%s", e.normalizedIndexName(), e.DigitalObjectSuffix)] = mapping.V2ESMapping
 	}
 
 	indexNames := []string{}

--- a/ikuzo/service/x/index/service.go
+++ b/ikuzo/service/x/index/service.go
@@ -224,7 +224,7 @@ func (s *Service) dropOrphanGroup(orgID, datasetID string, revision *domainpb.Re
 	v2 = v2.Must(elastic.NewTermQuery(c.Config.ElasticSearch.OrgIDKey, orgID))
 
 	res, err := index.ESClient().DeleteByQuery().
-		Index(c.Config.ElasticSearch.GetIndexName()).
+		Index(c.Config.ElasticSearch.GetDigitalObjectIndexName()).
 		Query(v2).
 		Conflicts("proceed"). // default is abort
 		Do(context.Background())


### PR DESCRIPTION
When set in the config it creates a dedicated index for scans based on the v2 index with the given prefix. By just enabling this switch, it will switch between the two indices.

The goal is to enable especially heavy indices dedicated to digital objects to be managed and queried separate from the main index. For some RDF search operations this will enable a performance boost. The default remains a single v2 index.