### PR TITLE
prevent duplicate filenames in METS files

### DIFF
--- a/hub3/ead/dao.go
+++ b/hub3/ead/dao.go
@@ -167,11 +167,6 @@ func validateFindingAid(fa *eadpb.FindingAid) error {
 		return duplicateFilenamesErr
 	}
 
-	sortKeysNotOrderedErr := assertSortKeysAreOrdered(fa.Files, 1)
-	if sortKeysNotOrderedErr != nil {
-		return sortKeysNotOrderedErr
-	}
-
 	return nil
 }
 
@@ -185,24 +180,6 @@ func assertUniqueFilenames(files []*eadpb.File) error {
 		}
 
 		fileNames[file.Filename] = file.SortKey
-	}
-
-	return nil
-}
-
-func assertSortKeysAreOrdered(files []*eadpb.File, expectedStartingSortKey int32) error {
-	var sortKeyTracker int32
-	sortKeyTracker = expectedStartingSortKey
-
-	if sortKeyTracker == 0 {
-		sortKeyTracker = 1 // the default value
-	}
-
-	for _, file := range files {
-		if file.SortKey != sortKeyTracker {
-			return errors.New(fmt.Sprintf("file sortKey not in succeeding order for fileName: %s with sortKey %d", file.Filename, file.SortKey))
-		}
-		sortKeyTracker++
 	}
 
 	return nil

--- a/hub3/ead/dao_test.go
+++ b/hub3/ead/dao_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func Test_find_duplicates_in_filenames(t *testing.T) {
+func TestFindDuplicatesInFilenames(t *testing.T) {
 	tests := []struct {
 		name    string
 		wantErr bool
@@ -43,7 +43,7 @@ func Test_find_duplicates_in_filenames(t *testing.T) {
 	}
 }
 
-func Test_return_map_of_unique_filenames_with_their_sort_key(t *testing.T) {
+func TestReturnMapOfUniqueFilenamesWithTheirSortKey(t *testing.T) {
 	tests := []struct {
 		name    string
 		wantErr bool

--- a/hub3/ead/dao_test.go
+++ b/hub3/ead/dao_test.go
@@ -36,8 +36,8 @@ func TestFindDuplicatesInFilenames(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := mapToUniqueFilenamesWithSortKey(tt.items); (err != nil) != tt.wantErr {
-				t.Errorf("mapToUniqueFilenamesWithSortKey = %v, wantErr %v", err, tt.wantErr)
+			if err := assertUniqueFilenames(tt.items); (err != nil) != tt.wantErr {
+				t.Errorf("assertUniqueFilenames = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -47,30 +47,30 @@ func TestReturnMapOfUniqueFilenamesWithTheirSortKey(t *testing.T) {
 	tests := []struct {
 		name    string
 		wantErr bool
-		items   *map[string]int32
+		items   []*eadpb.File
 	}{
 		{
 			"Should not throw error because of happy flow",
 			false,
-			&map[string]int32{
-				"file_a": 1,
-				"file_b": 2,
+			[]*eadpb.File{
+				{Filename: "file_a", SortKey: 1},
+				{Filename: "file_a", SortKey: 2},
 			},
 		},
 		{
 			"Should throw error because the first sortKey is not as expected",
 			true,
-			&map[string]int32{
-				"file_a": 2,
-				"file_b": 3,
+			[]*eadpb.File{
+				{Filename: "file_a", SortKey: 2},
+				{Filename: "file_a", SortKey: 3},
 			},
 		},
 		{
 			"Should throw error because the sortKeys are not in succeeding order",
 			true,
-			&map[string]int32{
-				"file_a": 1,
-				"file_b": 3,
+			[]*eadpb.File{
+				{Filename: "file_a", SortKey: 1},
+				{Filename: "file_a", SortKey: 3},
 			},
 		},
 	}
@@ -79,8 +79,8 @@ func TestReturnMapOfUniqueFilenamesWithTheirSortKey(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			if err := validateSortKeysAreOrdered(tt.items, 1); (err != nil) != tt.wantErr {
-				t.Errorf("validateSortKeysAreOrdered = %v, wantErr %v", err, tt.wantErr)
+			if err := assertSortKeysAreOrdered(tt.items, 1); (err != nil) != tt.wantErr {
+				t.Errorf("assertSortKeysAreOrdered = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/hub3/ead/dao_test.go
+++ b/hub3/ead/dao_test.go
@@ -1,0 +1,87 @@
+package ead
+
+import (
+	"github.com/delving/hub3/hub3/ead/eadpb"
+	"testing"
+)
+
+func Test_find_duplicates_in_filenames(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+		length  int
+		items   []*eadpb.File
+	}{
+		{
+			"Should throw error because of a duplicate filename",
+			true,
+			1,
+			[]*eadpb.File{
+				{Filename: "file_a"},
+				{Filename: "file_a"},
+			},
+		},
+		{
+			"Should not throw error because of there are no duplicate filenames",
+			false,
+			1,
+			[]*eadpb.File{
+				{Filename: "file_a"},
+				{Filename: "file_b"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := mapToUniqueFilenamesWithSortKey(tt.items); (err != nil) != tt.wantErr {
+				t.Errorf("mapToUniqueFilenamesWithSortKey = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_return_map_of_unique_filenames_with_their_sort_key(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+		items   *map[string]int32
+	}{
+		{
+			"Should not throw error because of happy flow",
+			false,
+			&map[string]int32{
+				"file_a": 1,
+				"file_b": 2,
+			},
+		},
+		{
+			"Should throw error because the first sortKey is not as expected",
+			true,
+			&map[string]int32{
+				"file_a": 2,
+				"file_b": 3,
+			},
+		},
+		{
+			"Should throw error because the sortKeys are not in succeeding order",
+			true,
+			&map[string]int32{
+				"file_a": 1,
+				"file_b": 3,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateSortKeysAreOrdered(tt.items, 1); (err != nil) != tt.wantErr {
+				t.Errorf("validateSortKeysAreOrdered = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit will prevent a METS file from being processed when filenames are duplicate. The filename is the identifier in the end. 

Currently this makes that the file gets indexed to elastic search first and then updated because the document ID already exists. Resulting in a different set because the data in ES has no duplicates like the METS file has.