### PR TITLE
Remove tree.description field from _source during indexing.

### DIFF
--- a/ikuzo/storage/x/elasticsearch/mapping/update.go
+++ b/ikuzo/storage/x/elasticsearch/mapping/update.go
@@ -25,7 +25,7 @@ import (
 // this should prevent changes to the mapping that are not reflected in the update.
 // this is needed for all mappings that have strict fields.
 const (
-	v2MappingSha       = "fb1d72134758dea3"
+	v2MappingSha       = "43ecc389eb11238c"
 	v2UpdateMappingSha = "b8d4f29ec1e660df"
 	fragmentMappingSha = "7607ca7737d17e4a"
 )

--- a/ikuzo/storage/x/elasticsearch/mapping/v2.go
+++ b/ikuzo/storage/x/elasticsearch/mapping/v2.go
@@ -54,6 +54,11 @@ var v2Mapping = `{
 	"mappings":{
 			"dynamic": "strict",
 			"date_detection" : false,
+			"_source": {
+				"excludes": [
+					"tree.description"
+				]
+			},
 			"properties": {
 				"meta": {
 					"type": "object",
@@ -108,7 +113,7 @@ var v2Mapping = `{
 							}
 						},
 						"title": {"type": "text"},
-						"description": {"type": "text"},
+						"description": {"type": "text", "store": true},
 						"content": {"type": "text"},
 						"periodDesc": { "type": "keyword"},
 						"rawContent": {"type": "text", "store": false},


### PR DESCRIPTION
When search and collapsing the 'tree.description' field that contains all text from the EAD description with the tags removed can become very big. This could lead to reduced performance for elasticsearch on disks with low disk-io.

This change stores this field outside the '_source' field removing the need to retrieve this big field from disk when doing queries that require access to the '_source' field. 