### PR TITLE
CLI application for submitting bulk request to the bulk API endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - history of changes: see https://github.com/delving/hub3/compare/v0.2.0...master
 
+### Added
+
+- ClI subcommand 'bulk' to index bulk-requests that are serialized to disk [[GH-88]](https://github.com/delving/hub3/pull/88)
+
+### Fixed
+ 
+- Explicit initialisation of config for CLI subcommands instead of global on init [[GH-88]](https://github.com/delving/hub3/pull/88)
+
 ## v0.2.0 (2021-03-10)
 
 - history of changes: see https://github.com/delving/hub3/compare/v0.1.10...v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/google/go-cmp v0.5.1
 	github.com/google/gofuzz v1.1.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
+	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/jinzhu/gorm v1.9.15

--- a/go.sum
+++ b/go.sum
@@ -450,6 +450,7 @@ github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBt
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.9.1 h1:9PZfAcVEvez4yhLH2TBU64/h/z4xlFI80cWXRrxuKuM=
 github.com/hashicorp/go-hclog v0.9.1/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
@@ -464,6 +465,8 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
+github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=

--- a/ikuzo/ikuzoctl/cmd/bulk.go
+++ b/ikuzo/ikuzoctl/cmd/bulk.go
@@ -49,7 +49,7 @@ func init() {
 
 	bulkCmd.Flags().StringVarP(&requestPath, "dataPath", "p", ".", "Full path to orgIDs for the bulk.Requests.")
 	bulkCmd.Flags().StringVarP(&publishHost, "host", "", "http://localhost:3001", "network host of where target hub3 is running")
-	bulkCmd.Flags().IntVarP(&chunkSize, "chunkSize", "", 500, "network host of where target hub3 is running")
+	bulkCmd.Flags().IntVarP(&chunkSize, "chunkSize", "", 500, "size of number of records send per batch")
 }
 
 func publish(ctx context.Context, host, dataPath string) error {

--- a/ikuzo/ikuzoctl/cmd/bulk.go
+++ b/ikuzo/ikuzoctl/cmd/bulk.go
@@ -39,7 +39,6 @@ var bulkCmd = &cobra.Command{
 	We assume that the structure is 'orgID/datasetID/hubID.jsonl' and that each bulk.Request
 	is stored in a single file.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("bulk called")
 		log.Fatal(publish(cmd.Context(), publishHost, requestPath))
 	},
 }
@@ -53,7 +52,7 @@ func init() {
 }
 
 func publish(ctx context.Context, host, dataPath string) error {
-	p := bulk.NewPublisher(publishHost, requestPath)
+	p := bulk.NewPublisher(host, dataPath)
 	p.BulkSize = chunkSize
 
 	err := p.Do(ctx)

--- a/ikuzo/ikuzoctl/cmd/bulk.go
+++ b/ikuzo/ikuzoctl/cmd/bulk.go
@@ -36,7 +36,7 @@ var bulkCmd = &cobra.Command{
 	Short: "Load bulk.Request from disk",
 	Long: `Loading bulk.Requests serialized as line delimited json.
 
-	We assume that the structure is 'orgID/datasetID/hubID.jsonl' each bulk.Request
+	We assume that the structure is 'orgID/datasetID/hubID.jsonl' and that each bulk.Request
 	is stored in single file.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("bulk called")

--- a/ikuzo/ikuzoctl/cmd/bulk.go
+++ b/ikuzo/ikuzoctl/cmd/bulk.go
@@ -37,7 +37,7 @@ var bulkCmd = &cobra.Command{
 	Long: `Loading bulk.Requests serialized as line delimited json.
 
 	We assume that the structure is 'orgID/datasetID/hubID.jsonl' and that each bulk.Request
-	is stored in single file.`,
+	is stored in a single file.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("bulk called")
 		log.Fatal(publish(cmd.Context(), publishHost, requestPath))

--- a/ikuzo/ikuzoctl/cmd/bulk.go
+++ b/ikuzo/ikuzoctl/cmd/bulk.go
@@ -1,0 +1,65 @@
+/*
+Copyright © 2021 Delving B.V. <info@delving.eu>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/delving/hub3/ikuzo/service/x/bulk"
+	"github.com/spf13/cobra"
+)
+
+var (
+	requestPath string
+	publishHost string
+	chunkSize   int
+)
+
+// bulkCmd represents the bulk command
+var bulkCmd = &cobra.Command{
+	Use:   "bulk",
+	Short: "Load bulk.Request from disk",
+	Long: `Loading bulk.Requests serialized as line delimited json.
+
+	We assume that the structure is 'orgID/datasetID/hubID.jsonl' each bulk.Request
+	is stored in single file.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("bulk called")
+		log.Fatal(publish(cmd.Context(), publishHost, requestPath))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(bulkCmd)
+
+	bulkCmd.Flags().StringVarP(&requestPath, "dataPath", "p", ".", "Full path to orgIDs for the bulk.Requests.")
+	bulkCmd.Flags().StringVarP(&publishHost, "host", "", "http://localhost:3001", "network host of where target hub3 is running")
+	bulkCmd.Flags().IntVarP(&chunkSize, "chunkSize", "", 500, "network host of where target hub3 is running")
+}
+
+func publish(ctx context.Context, host, dataPath string) error {
+	p := bulk.NewPublisher(publishHost, requestPath)
+	p.BulkSize = chunkSize
+
+	err := p.Do(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to publish data: %w", err)
+	}
+
+	return nil
+}

--- a/ikuzo/ikuzoctl/cmd/root.go
+++ b/ikuzo/ikuzoctl/cmd/root.go
@@ -66,16 +66,12 @@ func Execute() {
 
 // nolint:gochecknoinits // required for cobra
 func init() {
-	cobra.OnInitialize(initConfig)
+	// cobra.OnInitialize(initConfig)
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is hub3.toml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/ikuzo/ikuzoctl/cmd/serve.go
+++ b/ikuzo/ikuzoctl/cmd/serve.go
@@ -27,6 +27,7 @@ var serveCmd = &cobra.Command{
 	Short: "A high performance webserver",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
+		initConfig()
 		serve()
 	},
 }

--- a/ikuzo/service/x/bulk/publisher.go
+++ b/ikuzo/service/x/bulk/publisher.go
@@ -1,0 +1,240 @@
+package bulk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/rs/zerolog/log"
+)
+
+type Publisher struct {
+	host       string
+	dataPath   string
+	BulkSize   int
+	client     *retryablehttp.Client
+	rw         sync.Mutex
+	requests   [][]byte
+	nrRequests uint64
+	nrSubmits  uint64
+}
+
+type PublisherStats struct {
+	NrRequests uint64
+	NrSubmits  uint64
+}
+
+func NewPublisher(host, dataPath string) *Publisher {
+	client := retryablehttp.NewClient()
+	client.RetryMax = 5
+
+	log.Logger = log.With().Caller().Logger()
+
+	return &Publisher{
+		host:     strings.TrimSuffix(host, "/"),
+		dataPath: dataPath,
+		BulkSize: 250,
+		client:   retryablehttp.NewClient(),
+	}
+}
+
+// Stats returns the number of request and submits by the Publisher
+func (p *Publisher) Stats() PublisherStats {
+	return PublisherStats{
+		NrRequests: atomic.LoadUint64(&p.nrRequests),
+		NrSubmits:  atomic.LoadUint64(&p.nrSubmits),
+	}
+}
+
+func (p *Publisher) MaxRetries(max int) {
+	p.client.RetryMax = max
+}
+
+// AppendBytes appends a bulk.Request as []byte to p.requests
+//
+// When p.requests > p.BulkSize it will submit the chunk to the endpoint
+func (p *Publisher) AppendBytes(b []byte) error {
+	p.requests = append(p.requests, b)
+	atomic.AddUint64(&p.nrRequests, 1)
+
+	if len(p.requests) >= p.BulkSize {
+		if err := p.send(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Append appends a bulk.Request as []byte to p.requests
+//
+// When p.requests > p.BulkSize it will submit the chunk to the endpoint
+func (p *Publisher) Append(request *Request) error {
+	b, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	return p.AppendBytes(b)
+}
+
+// Do parses the records in the dataPath and submits them in chunks to the Hub3 BulkAPI endpoint
+//
+// Chunks are defined by p.BulkSize.
+//
+// The expect directory structure is:
+//
+// {orgId}
+//		/{datasetID}
+//			/bulk
+//				/{hubid}.jsonl
+//
+// The jsonl file is assumed to be a bulk.Request serialized on a single line.
+// Inside the struct newlines can be escaped.
+//
+// It will call increment revision at the start and on final submit it will
+// clear orphans.
+func (p *Publisher) Do(ctx context.Context) error {
+	orgIDs, err := ioutil.ReadDir(p.dataPath)
+	if err != nil {
+		return fmt.Errorf("unable to find datapath path: %w", err)
+	}
+
+	for _, orgID := range orgIDs {
+		if !orgID.IsDir() {
+			continue
+		}
+
+		datasetIDs, err := ioutil.ReadDir(filepath.Join(p.dataPath, orgID.Name()))
+		if err != nil {
+			return fmt.Errorf("unable to find datasetID path: %w", err)
+		}
+
+		for _, datasetID := range datasetIDs {
+			if !datasetID.IsDir() {
+				continue
+			}
+
+			recordPath := filepath.Join(p.dataPath, orgID.Name(), datasetID.Name(), "bulk")
+
+			requests, err := ioutil.ReadDir(recordPath)
+			if err != nil {
+				return fmt.Errorf("unable to find path: %w", err)
+			}
+
+			if err := p.incrementRevision(orgID.Name(), datasetID.Name()); err != nil {
+				return err
+			}
+
+			for _, request := range requests {
+				requestPath := filepath.Join(recordPath, request.Name())
+
+				if !strings.HasSuffix(request.Name(), ".jsonl") {
+					continue
+				}
+
+				// log.Info().Str("path", requestPath).Msg("file being processed")
+
+				b, err := ioutil.ReadFile(requestPath)
+				if err != nil {
+					return fmt.Errorf("unable to read jsonl file; %w", err)
+				}
+
+				if err := p.AppendBytes(b); err != nil {
+					return err
+				}
+
+				select {
+				case <-ctx.Done():
+					log.Info().Msg("context canceled bulk loading")
+					return ctx.Err()
+				default:
+				}
+			}
+
+			if err := p.dropOrphans(orgID.Name(), datasetID.Name()); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *Publisher) endpoint() string {
+	return fmt.Sprintf("%s/api/index/bulk", p.host)
+}
+
+// send records to endpoint and reset p.records to empty
+func (p *Publisher) send() error {
+	p.rw.Lock()
+	defer p.rw.Unlock()
+
+	body := bytes.Join(p.requests, []byte("\n"))
+
+	resp, err := p.post(body)
+	if err != nil {
+		return fmt.Errorf("unable to post to endpoint: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 300 {
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		defer resp.Body.Close()
+
+		return fmt.Errorf("unable to post to endpoint: %s (%d)", string(b), resp.StatusCode)
+	}
+
+	atomic.AddUint64(&p.nrSubmits, 1)
+
+	log.Info().Uint64("submits", p.nrSubmits).Uint64("processed", p.nrRequests).Msg("bulk publishing progress")
+
+	p.requests = nil
+
+	return nil
+}
+
+func (p *Publisher) post(body []byte) (*http.Response, error) {
+	return p.client.Post(p.endpoint(), "text/plain", body)
+}
+
+func (p *Publisher) incrementRevision(orgID, datasetID string) error {
+	req := Request{
+		OrgID:     orgID,
+		DatasetID: datasetID,
+		Action:    "increment_revision",
+	}
+
+	err := p.Append(&req)
+	if err != nil {
+		return err
+	}
+
+	return p.send()
+}
+
+func (p *Publisher) dropOrphans(orgID, datasetID string) error {
+	req := Request{
+		OrgID:     orgID,
+		DatasetID: datasetID,
+		Action:    "drop_orphans",
+	}
+
+	err := p.Append(&req)
+	if err != nil {
+		return err
+	}
+
+	return p.send()
+}

--- a/ikuzo/service/x/bulk/publisher.go
+++ b/ikuzo/service/x/bulk/publisher.go
@@ -90,7 +90,7 @@ func (p *Publisher) Append(request *Request) error {
 //
 // Chunks are defined by p.BulkSize.
 //
-// The expect directory structure is:
+// The expected directory structure is:
 //
 // {orgId}
 //		/{datasetID}

--- a/ikuzo/service/x/bulk/publisher.go
+++ b/ikuzo/service/x/bulk/publisher.go
@@ -185,7 +185,7 @@ func (p *Publisher) send() error {
 		return fmt.Errorf("unable to post to endpoint: %w", err)
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode > 300 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err

--- a/ikuzo/service/x/index/service.go
+++ b/ikuzo/service/x/index/service.go
@@ -280,6 +280,8 @@ func (s *Service) dropOrphans(orgID, datasetID string, revision *domainpb.Revisi
 
 		if ds.Revision != int(revision.GetNumber()) {
 			log.Warn().
+				Str("orgID", orgID).
+				Str("datasetID", datasetID).
 				Int32("message_revision", revision.GetNumber()).
 				Int("dataset_revision", ds.Revision).
 				Msg("message revision is older so not dropping orphans")


### PR DESCRIPTION
The goal of this pull request is to have a default method to load serialized bulk-requests from disk and send them to the bulk-API endpoint.

* Config initiation is no longer default for cobra based cli application.
* bulk CLI sub-command has been added
* bulk package is extended with a publisher client that can be used as a library.