### PR TITLE
Feature/split filter and collapse query in ead overview search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@
 ### Added 
 
 - Config option to store records generated from METS files in dedicated index [[GH-83]](https://github.com/delving/hub3/pull/83)
+
+## Changed 
 - Allow for changes to uploaded EAD file before storing it [[GH-90]](https://github.com/delving/hub3/pull/90)
+-  Refactored EAD search overview queries into separate filter and collapse queries [[GH-91]](https://github.com/delving/hub3/pull/91)
 
 ### Fixed
 

--- a/hub3/ead/cache.go
+++ b/hub3/ead/cache.go
@@ -1,0 +1,65 @@
+package ead
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/allegro/bigcache"
+	cfg "github.com/delving/hub3/config"
+	"github.com/rs/zerolog"
+)
+
+var httpCache *bigcache.BigCache
+
+func newBigCache() {
+	config := bigcache.Config{
+		Shards:           1024,
+		HardMaxCacheSize: cfg.Config.Cache.HardMaxCacheSize,
+		LifeWindow:       time.Duration(cfg.Config.Cache.LifeWindowMinutes) * time.Minute,
+		CleanWindow:      5 * time.Minute,
+		MaxEntrySize:     cfg.Config.Cache.MaxEntrySize,
+	}
+
+	var err error
+
+	httpCache, err = bigcache.NewBigCache(config)
+	if err != nil {
+		cfg.Config.Logger.Warn().Err(err).Msg("cannot start bigcache running without cache; %#v")
+	}
+
+	rlog := cfg.Config.Logger.With().Str("test", "sublogger").Logger()
+	rlog.Info().Msg("starting bigCache for request caching")
+}
+
+func getCachedRequest(requestKey string, rlog *zerolog.Logger) *SearchResponse {
+	entry, cacheErr := httpCache.Get(requestKey)
+	if cacheErr != nil {
+		rlog.Debug().Str("cache_key", requestKey).Err(cacheErr).Msg("cache miss")
+		return nil
+	}
+
+	var eadResponse SearchResponse
+
+	jsonErr := json.Unmarshal(entry, &eadResponse)
+	if jsonErr != nil {
+		rlog.Warn().Err(jsonErr).Msg("unable to unmarshall cached response")
+		return nil
+	}
+
+	rlog.Debug().Str("cache_key", requestKey).Msg("returning response from cache")
+
+	return &eadResponse
+}
+
+func storeResponseInCache(requestKey string, response *SearchResponse, rlog *zerolog.Logger) {
+	b, err := json.Marshal(response)
+	if err != nil {
+		rlog.Error().Err(err).Msg("unable to marshal eadResponse for caching")
+	} else {
+		cacheErr := httpCache.Set(requestKey, b)
+		if cacheErr != nil {
+			rlog.Error().Err(cacheErr).Msg("unable to cache searchResponse")
+		}
+		rlog.Debug().Str("cache_key", requestKey).Msg("set cache for key")
+	}
+}

--- a/hub3/ead/searchrequest.go
+++ b/hub3/ead/searchrequest.go
@@ -1,0 +1,247 @@
+package ead
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/OneOfOne/xxhash"
+	cfg "github.com/delving/hub3/config"
+	"github.com/delving/hub3/hub3/fragments"
+	elastic "github.com/olivere/elastic/v7"
+	"github.com/rs/zerolog"
+)
+
+// SearchRequest holds all information for EAD search
+type SearchRequest struct {
+	Page             int
+	Rows             int
+	Query            *elastic.BoolQuery
+	RawQuery         string
+	Service          *elastic.SearchService
+	FacetFields      []string
+	Filters          []*fragments.QueryFilter
+	FacetSize        int
+	FacetAndBoolType bool
+	SortBy           string
+	NestedSortField  string
+	SortAsc          bool
+	NoCache          bool
+	CacheRefresh     bool
+	CacheReset       bool
+	InventoryID      string
+	Explain          bool
+	EchoService      bool
+	rlog             *zerolog.Logger
+	fub              *fragments.FacetURIBuilder
+	postFilter       elastic.Query
+}
+
+func newSearchRequest(params url.Values) (*SearchRequest, error) {
+	sr := &SearchRequest{
+		Page:            1,
+		Rows:            10,
+		NestedSortField: "@value.keyword",
+		FacetSize:       50,
+		Filters:         []*fragments.QueryFilter{},
+	}
+
+	rlog := cfg.Config.Logger.With().
+		Str("application", "hub3").
+		Str("search.type", "request builder").
+		Logger()
+
+	sr.rlog = &rlog
+
+	logConvErr := func(p string, v []string, err error) {
+		sr.rlog.Error().Err(err).
+			Str("param", p).
+			Msgf("unable to convert %v to int", v)
+
+	}
+
+	for p, v := range params {
+		switch p {
+		case "rows":
+			size, err := strconv.Atoi(params.Get(p))
+			if err != nil {
+				logConvErr(p, v, err)
+
+				return nil, err
+			}
+
+			if size > 100 {
+				size = 100
+			}
+
+			sr.Rows = size
+		case "facet.size":
+			size, err := strconv.Atoi(params.Get(p))
+			if err != nil {
+				logConvErr(p, v, err)
+
+				return nil, err
+			}
+
+			if size > 100 {
+				size = 100
+			}
+
+			sr.FacetSize = size
+		case "FacetBoolType":
+			fbt := params.Get(p)
+			if fbt != "" {
+				sr.FacetAndBoolType = strings.EqualFold(fbt, "and")
+			}
+		case "page":
+			rawPage, err := strconv.Atoi(params.Get(p))
+			if err != nil {
+				logConvErr(p, v, err)
+
+				return nil, err
+			}
+
+			if rawPage == 0 {
+				err := fmt.Errorf("0 pages is not allowed. Paging starts at 1")
+				sr.rlog.Error().Err(err).
+					Str("param", p).
+					Msg("")
+
+				return nil, err
+			}
+
+			sr.Page = rawPage
+		case "sortBy":
+			sortKey := params.Get(p)
+			if strings.HasPrefix(sortKey, "^") {
+				sr.SortAsc = true
+				sortKey = strings.TrimPrefix(sortKey, "^")
+			}
+
+			if strings.HasPrefix(sortKey, "int.") {
+				sr.NestedSortField = "integer"
+				sortKey = strings.TrimPrefix(sortKey, "int.")
+			}
+
+			sr.SortBy = sortKey
+		case "q", "query":
+			sr.RawQuery = params.Get(p)
+		case "facet.field":
+			sr.FacetFields = v
+		case "qf", "qf[]":
+			for _, filter := range v {
+				qf, err := fragments.NewQueryFilter(filter)
+				if err != nil {
+					sr.rlog.Error().Err(err).
+						Str("param", p).
+						Msg("error in filter gerenation")
+
+					return nil, err
+				}
+
+				sr.Filters = append(sr.Filters, qf)
+			}
+		case "qf.dateRange", "qf.dateRange[]":
+			for _, filter := range v {
+				qf, err := fragments.NewDateRangeFilter(filter)
+				if err != nil {
+					sr.rlog.Error().Err(err).
+						Str("param", p).
+						Msg("error in daterange filter gerenation")
+
+					return sr, err
+				}
+
+				sr.Filters = append(sr.Filters, qf)
+			}
+		case "noCache":
+			sr.NoCache = strings.EqualFold(params.Get(p), "true")
+		case "cacheRefresh":
+			sr.CacheRefresh = strings.EqualFold(params.Get(p), "true")
+		case "cacheReset":
+			sr.CacheReset = strings.EqualFold(params.Get(p), "true")
+		}
+	}
+
+	return sr, nil
+}
+
+func (sr *SearchRequest) SetFragmentURIBuilder() error {
+	fub, err := fragments.NewFacetURIBuilder(sr.RawQuery, sr.Filters)
+	if err != nil {
+		return err
+	}
+
+	sr.fub = fub
+	return nil
+}
+
+func (sr *SearchRequest) SetPostFilter() error {
+	if sr.fub == nil {
+		if err := sr.SetFragmentURIBuilder(); err != nil {
+			return err
+		}
+	}
+
+	postFilter, err := sr.fub.CreateFacetFilterQuery("", sr.FacetAndBoolType)
+	if err != nil {
+		sr.rlog.Error().Err(err).Msg("unable to create search postfilter")
+		return err
+	}
+
+	sr.Service = sr.Service.PostFilter(postFilter)
+	sr.postFilter = postFilter
+
+	return nil
+}
+
+func (sr *SearchRequest) requestKey() string {
+	jsonBytes, err := json.Marshal(sr)
+	if err != nil {
+		cfg.Config.Logger.Error().Err(err).
+			Msg("unable to marshal request key")
+
+		return ""
+	}
+
+	hash := xxhash.Checksum64(jsonBytes)
+
+	return fmt.Sprintf("%016x", hash)
+}
+
+func (sr *SearchRequest) enableDescriptionSearch() bool {
+	for _, f := range sr.Filters {
+		if f.SearchLabel != "ead-rdf_periodDesc" {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (sr *SearchRequest) Do(ctx context.Context, label string) (*elastic.SearchResult, error) {
+	resp, err := sr.Service.Do(ctx)
+
+	queryStart := time.Now()
+	sr.rlog.Info().
+		Int("status", resp.Status).
+		Int64("esTimeInMillis", resp.TookInMillis).
+		Dur("duration", time.Since(queryStart)).
+		Str("searchType", label).
+		Msg("elastic ead cluster search request")
+
+	if err != nil {
+		sr.rlog.Error().Err(err).Msg("error in elasticsearch response")
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (sr *SearchRequest) createSearchResponse(collapseResponse, aggResponse *elastic.SearchResult) (*SearchResponse, error) {
+	return createSearchResponse(sr, collapseResponse, aggResponse)
+}

--- a/hub3/ead/searchresponse.go
+++ b/hub3/ead/searchresponse.go
@@ -1,0 +1,247 @@
+package ead
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"unsafe"
+
+	"github.com/delving/hub3/hub3/fragments"
+	elastic "github.com/olivere/elastic/v7"
+)
+
+// SearchResponse contains the EAD Search response.
+type SearchResponse struct {
+
+	// ArchiveCount returns the number of collapsed Archives that match the search  query
+	ArchiveCount int `json:"archiveCount"`
+
+	// Cursor the location of the first result in the ElasticSearch search response
+	Cursor int `json:"cursor"`
+
+	// TotalPages is the total number of pages in the search response
+	TotalPages int `json:"totalPages"`
+
+	// TotalClevelCount returns the total number of clevel that mathc the search query
+	// this counts is per clevel, so multiple hits inside a clevel are counted as one
+	TotalClevelCount int `json:"totalClevelCount"`
+
+	// TotalDescriptionCount returns the total number of hits in the description.
+	// This is an cardinatility aggregation so each hit inside the decription counts as a hit.
+	TotalDescriptionCount int `json:"totalDescriptionCount"`
+
+	// TotalHits is a combination of TotalClevelCount and TotalDescriptiontCount.
+	TotalHits int `json:"totalHits"`
+
+	// Archives contains the list of archives from the response constrained by the search pagination
+	Archives []Archive `json:"archives"`
+
+	// CLevels contains a paged result of the cLevels for a specific archive that match the search query
+	// It is ordered by the ead orderKey.
+	CLevels []CLevelEntry `json:"cLevels,omitempty"`
+
+	// Facets holds the QueryFacets for filtering
+	Facets []*fragments.QueryFacet `json:"facets,omitempty"`
+
+	// Explain response from elasticsearch
+	Explain *elastic.SearchResult `json:"explain,omitempty"`
+
+	// Service is the elasticsearch query
+	Service interface{} `json:"service,omitempty"`
+}
+
+// CLevel holds the search results per clevel entry in the an EAD Archive.
+type CLevelEntry struct {
+
+	// Path is the unique key to the path of the clevel in the archive tree
+	Path string `json:"path"`
+
+	// UnitID is the identifier of the clevel
+	UnitID string `json:"unitID"`
+
+	// Label is the title of the clevel
+	Label string `json:"label"`
+
+	// HubID is the unique identifier of the clevel as stored in the hub3 index
+	HubID string `json:"hubID"`
+
+	// ResultOrder is the place the search result has in the total list of results.
+	// This can be used to aid the search pagination on the Archive result page.
+	ResultOrder uint64 `json:"sortKey"`
+}
+
+// Archive holds all information for the EAD search results that are grouped
+// by inventoryID. This is the EadID from the EAD header.
+type Archive struct {
+	InventoryID      string   `json:"inventoryID"`
+	Title            string   `json:"title"`
+	Period           []string `json:"period"`
+	CLevelCount      int      `json:"cLevelCount"`
+	DescriptionCount int      `json:"descriptionCount"`
+	Files            string   `json:"files,omitempty"`
+	Length           string   `json:"length,omitempty"`
+	Abstract         []string `json:"abstract,omitempty"`
+	Material         string   `json:"material,omitempty"`
+	Language         string   `json:"language,omitempty"`
+	Origin           []string `json:"origin,omitempty"`
+	MetsFiles        int      `json:"metsFiles,omitempty"`
+	ClevelsTotal     int      `json:"clevelsTotal"`
+}
+
+func createSearchResponse(sr *SearchRequest, collapseResponse, aggResponse *elastic.SearchResult) (*SearchResponse, error) {
+	eadResponse := &SearchResponse{
+		Archives: []Archive{},
+	}
+
+	if sr.Explain {
+		eadResponse.Explain = collapseResponse
+	}
+
+	if sr.EchoService {
+		ss := reflect.ValueOf(sr.Service).Elem().FieldByName("searchSource")
+		src := reflect.NewAt(ss.Type(), unsafe.Pointer(ss.UnsafeAddr())).Elem().Interface().(*elastic.SearchSource)
+
+		srcMap, sourceErr := src.Source()
+		if sourceErr != nil {
+			sr.rlog.Error().Err(sourceErr).
+				Msg("unable to decode elastich search request")
+
+			return nil, sourceErr
+		}
+
+		eadResponse.Service = srcMap
+	}
+
+	// set total description count
+	unFilteredEadTypeCount, ok := aggResponse.Aggregations.Terms("noFiltTypeCount")
+	if ok {
+		for _, b := range unFilteredEadTypeCount.Buckets {
+			if b.Key == "eadDesc" {
+				eadResponse.TotalDescriptionCount = int(b.DocCount)
+			}
+		}
+	}
+
+	// set counts for number of archives and inventories (clevels) returned
+	filteredAgg, ok := aggResponse.Aggregations.Filter("counts")
+	if ok {
+		specCount, ok := filteredAgg.Aggregations.Cardinality("specCount")
+		if ok {
+			eadResponse.ArchiveCount = int(*specCount.Value)
+			eadResponse.TotalPages = getPageCount(eadResponse.ArchiveCount, sr.Rows)
+		}
+
+		eadTypeCount, ok := filteredAgg.Aggregations.Terms("typeCount")
+		if ok {
+			for _, b := range eadTypeCount.Buckets {
+				if b.Key == "ead" {
+					eadResponse.TotalClevelCount = int(b.DocCount)
+				}
+			}
+		}
+	}
+
+	// total unique search hits in the response
+	eadResponse.TotalHits = eadResponse.TotalClevelCount + eadResponse.TotalDescriptionCount
+
+	cursor := getCursor(sr.Rows, sr.Page)
+	if cursor > eadResponse.ArchiveCount {
+		pageErr := fmt.Errorf(
+			"page start %d requested is greater then records returned: %d",
+			cursor,
+			eadResponse.ArchiveCount,
+		)
+		sr.rlog.Error().Err(pageErr).
+			Msg("request error")
+
+		return nil, pageErr
+	}
+
+	eadResponse.Cursor = cursor
+
+	if !sr.enableDescriptionSearch() {
+		eadResponse.TotalDescriptionCount = 0
+	}
+
+	// build facets
+	aggs, err := fragments.DecodeFacets(aggResponse, sr.fub)
+	if err != nil {
+		sr.rlog.Error().Err(err).
+			Msg("facet decode error")
+
+		return nil, err
+	}
+
+	eadResponse.Facets = aggs
+
+	if !sr.enableDescriptionSearch() {
+		eadResponse.TotalDescriptionCount = 0
+	}
+
+	return eadResponse, nil
+}
+
+func decodeHits(sr *SearchRequest, hits *elastic.SearchHits) ([]Archive, error) {
+	archives := []Archive{}
+
+	var err error
+
+	for _, hit := range hits.Hits {
+		fields, ok := hit.Fields[specField]
+		if ok {
+			spec := fields.([]interface{})[0].(string)
+
+			meta, metaErr := GetMeta(spec)
+			if metaErr != nil {
+				sr.rlog.Error().Err(metaErr).
+					Str("spec", spec).
+					Msg("unable to ead meta information")
+
+				return nil, metaErr
+			}
+
+			archive := Archive{
+				InventoryID:      spec,
+				Title:            meta.Label,
+				Period:           meta.Period,
+				DescriptionCount: 0,
+				ClevelsTotal:     meta.Inventories,
+			}
+
+			var hitHasDescription bool
+
+			inner, ok := hit.InnerHits["collapse"]
+			if ok {
+				archive.CLevelCount = int(inner.Hits.TotalHits.Value)
+
+				if len(inner.Hits.Hits) > 0 {
+					r := new(fragments.FragmentGraph)
+
+					if unmarshallErr := json.Unmarshal(inner.Hits.Hits[0].Source, r); unmarshallErr != nil {
+						sr.rlog.Error().Err(unmarshallErr).
+							Msg("unable to unmarshal json for elasticsearch hit")
+
+						return nil, unmarshallErr
+					}
+
+					if r.Tree.InventoryID != "" {
+						archive.CLevelCount--
+						archive.DescriptionCount = 1
+						hitHasDescription = true
+					}
+				}
+			}
+
+			if sr.RawQuery != "" && sr.enableDescriptionSearch() && hitHasDescription {
+				archive.DescriptionCount, err = GetDescriptionCount(spec, sr.RawQuery)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			archives = append(archives, archive)
+		}
+	}
+
+	return archives, nil
+}


### PR DESCRIPTION
Refactor EAD search overview into two queries.

When you separate the aggregation and the collapse query the ElasticSearch caches are used more efficiently. The result is a significantly faster query and less load on the ElasticSearch cluster even though you send two queries instead of one.
