### PR TITLE
Fix response when doing API request /api/tree/1.01.02/%40IX.?fillTree…

### DIFF
--- a/hub3/server/http/handlers/search.go
+++ b/hub3/server/http/handlers/search.go
@@ -449,7 +449,7 @@ func ProcessSearchRequest(w http.ResponseWriter, r *http.Request, searchRequest 
 				var pageParam string
 
 				for _, page := range pages {
-					pageParam = fmt.Sprintf("%s&page=%d", pageParam, page)
+					pageParam = fmt.Sprintf("%s&treePage=%d", pageParam, page)
 				}
 				qs := fmt.Sprintf("paging=true%s", pageParam)
 				m, _ := url.ParseQuery(qs)


### PR DESCRIPTION
When doing the tree api request  /api/tree/1.01.02/%40IX.?fillTree=true&page=1&q=&withFields=true&paging=true it used to give a tree response back for inventoryID=@IX. on page 114 but the recent addition of treePage parameter broke that request. This should fix it.