### PR TITLE
Show all EAD unittitles in tree.Label output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Tree paging was using the old API key [[GH-93]](https://github.com/delving/hub3/pull/93)
 - Delete non-EAD datasets would return incorrect error  [[GH-10]](https://github.com/delving/hub3/pull/102)
 - Sanitation in EAD unittitle was too strict [[GH-109]](https://github.com/delving/hub3/pull/109)
+- Show all EAD unittitles in tree.Label [[GH-110]](https://github.com/delving/hub3/pull/110)
 
 ### Removed
 

--- a/hub3/ead/ead.go
+++ b/hub3/ead/ead.go
@@ -318,7 +318,7 @@ func (h *Header) GetTreeLabel() string {
 	if len(h.Label) == 0 {
 		return ""
 	}
-	return html.UnescapeString(h.Label[0])
+	return html.UnescapeString(strings.Join(h.Label, "; "))
 }
 
 // NewNodeID converts a unitid field from the EAD did to a NodeID


### PR DESCRIPTION
Previously, only the first title was shown.