### PR TITLE
Fix: ead redirect loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Delete non-EAD datasets would return incorrect error  [[GH-10]](https://github.com/delving/hub3/pull/102)
 - Sanitation in EAD unittitle was too strict [[GH-109]](https://github.com/delving/hub3/pull/109)
 - Show all EAD unittitles in tree.Label [[GH-110]](https://github.com/delving/hub3/pull/110)
+- Prevent redirect loop with invalid 'inventoryID' in tree API [[GH-112]](https://github.com/delving/hub3/pull/112)
 
 ### Removed
 

--- a/hub3/server/http/handlers/search.go
+++ b/hub3/server/http/handlers/search.go
@@ -417,6 +417,11 @@ func ProcessSearchRequest(w http.ResponseWriter, r *http.Request, searchRequest 
 
 		// with zero results load the default first page
 		if paging.HitsTotalCount == 0 && searchRequest.Tree.IsSearch && searchRequest.Tree.IsPaging {
+			// if there is no query in the params then this is already a redirect
+			if !r.URL.Query().Has("q") {
+				http.Error(w, fmt.Sprintf("inventoryID '%s' not found", searchRequest.Tree.UnitID), http.StatusNotFound)
+				return
+			}
 			newPath := fmt.Sprintf("%s?paging=true&page=1", r.URL.Path)
 			http.Redirect(w, r, newPath, http.StatusSeeOther)
 			return


### PR DESCRIPTION
When no result is found for a query in the tree API with an inventoryID, you are redirected to the first result page. When the inventoryID is invalid, it can create a redirectloop, see #111. 

This pull-request returns a 404 when the first page returns zero results. 