### PR TITLE
Bugfix/ead redirect loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Tree paging was using the old API key [[GH-93]](https://github.com/delving/hub3/pull/93)
 - Delete non-EAD datasets would return incorrect error  [[GH-10]](https://github.com/delving/hub3/pull/102)
 - Sanitation in EAD unittitle was too strict [[GH-109]](https://github.com/delving/hub3/pull/109)
+- Show all EAD unittitles in tree.Label [[GH-110]](https://github.com/delving/hub3/pull/110)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## Changed 
 - Allow for changes to uploaded EAD file before storing it [[GH-90]](https://github.com/delving/hub3/pull/90)
--  Refactored EAD search overview queries into separate filter and collapse queries [[GH-91]](https://github.com/delving/hub3/pull/91)
+- Refactored EAD search overview queries into separate filter and collapse queries [[GH-91]](https://github.com/delving/hub3/pull/91)
 - Added support for NDE Dataset Register API [[GH-92]](https://github.com/delving/hub3/pull/92)
 - Added posthooks support to orphan groups as well  [[GH-99]](https://github.com/delving/hub3/pull/99)
 - Added Run() custom function to posthook interface [[GH-107]](https://github.com/delving/hub3/pull/107)
@@ -26,6 +26,7 @@
 - Sanitation in EAD unittitle was too strict [[GH-109]](https://github.com/delving/hub3/pull/109)
 - Show all EAD unittitles in tree.Label [[GH-110]](https://github.com/delving/hub3/pull/110)
 - Prevent redirect loop with invalid 'inventoryID' in tree API [[GH-112]](https://github.com/delving/hub3/pull/112)
+- Prevent 404 when call is made to /ead/tree without "q" parameter
 
 ### Removed
 

--- a/hub3/ead/ead.go
+++ b/hub3/ead/ead.go
@@ -318,7 +318,7 @@ func (h *Header) GetTreeLabel() string {
 	if len(h.Label) == 0 {
 		return ""
 	}
-	return html.UnescapeString(h.Label[0])
+	return html.UnescapeString(strings.Join(h.Label, "; "))
 }
 
 // NewNodeID converts a unitid field from the EAD did to a NodeID

--- a/hub3/server/http/handlers/search.go
+++ b/hub3/server/http/handlers/search.go
@@ -418,7 +418,7 @@ func ProcessSearchRequest(w http.ResponseWriter, r *http.Request, searchRequest 
 		// with zero results load the default first page
 		if paging.HitsTotalCount == 0 && searchRequest.Tree.IsSearch && searchRequest.Tree.IsPaging {
 			// if there is no query in the params then this is already a redirect
-			if !r.URL.Query().Has("q") {
+			if !r.URL.Query().Has("q") && !r.URL.Query().Has("query") && !r.URL.Query().Has("byQuery") {
 				http.Error(w, fmt.Sprintf("inventoryID '%s' not found", searchRequest.Tree.UnitID), http.StatusNotFound)
 				return
 			}

--- a/hub3/server/http/handlers/search.go
+++ b/hub3/server/http/handlers/search.go
@@ -417,6 +417,11 @@ func ProcessSearchRequest(w http.ResponseWriter, r *http.Request, searchRequest 
 
 		// with zero results load the default first page
 		if paging.HitsTotalCount == 0 && searchRequest.Tree.IsSearch && searchRequest.Tree.IsPaging {
+			// if there is no query in the params then this is already a redirect
+			if !r.URL.Query().Has("q") {
+				http.Error(w, fmt.Sprintf("inventoryID '%s' not found", searchRequest.Tree.UnitID), http.StatusNotFound)
+				return
+			}
 			newPath := fmt.Sprintf("%s?paging=true&page=1", r.URL.Path)
 			http.Redirect(w, r, newPath, http.StatusSeeOther)
 			return


### PR DESCRIPTION
Prevent 404 when call is made to /ead/tree without "q" parameter.  Both 'query' and 'byQuery' are valid parameters as well.

This was causing some issues with automated regression tests.