### PR TITLE
HUB-378 PeriodDesc in daoCfg and FindingAid

### DIFF
--- a/hub3/ead/dao.go
+++ b/hub3/ead/dao.go
@@ -371,6 +371,7 @@ type DaoConfig struct {
 	MimeTypes      []string
 	RevisionKey    string
 	FilterTypes    []string
+	Periods        []string
 }
 
 func getUUID(daoLink string) string {
@@ -389,6 +390,7 @@ func newDaoConfig(cfg *NodeConfig, tree *fragments.Tree) DaoConfig {
 		InventoryTitle: tree.Label,
 		Link:           tree.DaoLink,
 		UUID:           getUUID(tree.DaoLink),
+		Periods:        tree.Periods,
 	}
 }
 

--- a/hub3/ead/mets.go
+++ b/hub3/ead/mets.go
@@ -290,7 +290,9 @@ func findingAidTriples(subject string, fa *eadpb.FindingAid, daoCfg *DaoConfig) 
 		t(s, "fileUUID", file.Fileuuid, rdf.NewLiteral)
 		t(s, "recordUUID", file.Filename, rdf.NewLiteral)
 	}
-
+	for _, period := range daoCfg.Periods {
+		t(s, "periodDesc", period, rdf.NewLiteral)
+	}
 	t(s, "dao", daoCfg.Link, rdf.NewLiteral)
 
 	return triples


### PR DESCRIPTION
We needed periodDesc in the findingAid documents for filtering with a date range. I added periodDesc to daoCfg  so we can pass it to the findingAidTriples method.