### PR TITLE
Ignore private resources in bulk sparql export.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Imageproxy: lrucache, deepzoom and thumbnail transformation support [[GH-115]](https://github.com/delving/hub3/pull/115)
 - Added support for indexing map datatypes in scans indexed from METS files [[GH-117]](https://github.com/delving/hub3/pull/117)
 - PeriodDesc in daoCfg and FindingAid [[GH-118]](https://github.com/delving/hub3/pull/118)
+- Ignore private resources in bulk sparql export [[GH-123]](https://github.com/delving/hub3/pull/123)
 
 ## Changed 
 - Allow for changes to uploaded EAD file before storing it [[GH-90]](https://github.com/delving/hub3/pull/90)

--- a/ikuzo/service/x/bulk/parser.go
+++ b/ikuzo/service/x/bulk/parser.go
@@ -137,7 +137,7 @@ func (p *Parser) Parse(ctx context.Context, r io.Reader) error {
 
 // RDFBulkInsert inserts all triples from the bulkRequest in one SPARQL update statement
 func (p *Parser) RDFBulkInsert() []error {
-	triplesStored, errs := fragments.RDFBulkInsert(p.ds.OrgID, p.sparqlUpdates)
+	triplesStored, errs := fragments.RDFBulkInsert(p.sparqlUpdates)
 	p.sparqlUpdates = nil
 	p.stats.TriplesStored = uint64(triplesStored)
 

--- a/ikuzo/service/x/bulk/parser.go
+++ b/ikuzo/service/x/bulk/parser.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/kiivihal/rdf2go"
 	rdf "github.com/kiivihal/rdf2go"
 )
 
@@ -136,7 +137,7 @@ func (p *Parser) Parse(ctx context.Context, r io.Reader) error {
 
 // RDFBulkInsert inserts all triples from the bulkRequest in one SPARQL update statement
 func (p *Parser) RDFBulkInsert() []error {
-	triplesStored, errs := fragments.RDFBulkInsert(p.sparqlUpdates)
+	triplesStored, errs := fragments.RDFBulkInsert(p.ds.OrgID, p.sparqlUpdates)
 	p.sparqlUpdates = nil
 	p.stats.TriplesStored = uint64(triplesStored)
 
@@ -333,7 +334,7 @@ func (p *Parser) Publish(ctx context.Context, req *Request) error {
 // AppendRDFBulkRequest gathers all the triples from an BulkAction to be inserted in bulk.
 func (p *Parser) AppendRDFBulkRequest(req *Request, g *rdf.Graph) error {
 	var b bytes.Buffer
-	if err := g.Serialize(&b, "text/turtle"); err != nil {
+	if err := serializeTurtle(g, &b); err != nil {
 		return fmt.Errorf("unable to convert RDF graph; %w", err)
 	}
 
@@ -360,4 +361,64 @@ type Stats struct {
 	TriplesStored      uint64 `json:"triplesStored"`
 	PostHooksSubmitted uint64 `json:"postHooksSubmitted"`
 	// ContentHashMatches uint64    `json:"contentHashMatches"` // originally json was content_hash_matches
+}
+
+func encodeTerm(iterm rdf2go.Term) string {
+	switch term := iterm.(type) {
+	case *rdf2go.Resource:
+		return fmt.Sprintf("<%s>", term.URI)
+	case *rdf2go.Literal:
+		return term.String()
+	case *rdf2go.BlankNode:
+		return term.String()
+	}
+
+	return ""
+}
+
+func serializeTurtle(g *rdf2go.Graph, w io.Writer) error {
+	var err error
+
+	triplesBySubject := make(map[string][]*rdf2go.Triple)
+
+	for triple := range g.IterTriples() {
+		s := encodeTerm(triple.Subject)
+		if strings.HasPrefix(s, "<urn:private/") {
+			continue
+		}
+
+		triplesBySubject[s] = append(triplesBySubject[s], triple)
+	}
+
+	for subject, triples := range triplesBySubject {
+		_, err = fmt.Fprintf(w, "%s\n", subject)
+		if err != nil {
+			return err
+		}
+
+		for key, triple := range triples {
+			p := encodeTerm(triple.Predicate)
+			o := encodeTerm(triple.Object)
+
+			if strings.HasPrefix(o, "<urn:private/") {
+				continue
+			}
+
+			if key == len(triples)-1 {
+				_, err = fmt.Fprintf(w, "  %s %s .\n", p, o)
+				if err != nil {
+					return err
+				}
+
+				break
+			}
+
+			_, err = fmt.Fprintf(w, "  %s %s ;\n", p, o)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/ikuzo/service/x/bulk/parser.go
+++ b/ikuzo/service/x/bulk/parser.go
@@ -35,7 +35,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/kiivihal/rdf2go"
 	rdf "github.com/kiivihal/rdf2go"
 )
 
@@ -363,23 +362,23 @@ type Stats struct {
 	// ContentHashMatches uint64    `json:"contentHashMatches"` // originally json was content_hash_matches
 }
 
-func encodeTerm(iterm rdf2go.Term) string {
+func encodeTerm(iterm rdf.Term) string {
 	switch term := iterm.(type) {
-	case *rdf2go.Resource:
+	case *rdf.Resource:
 		return fmt.Sprintf("<%s>", term.URI)
-	case *rdf2go.Literal:
+	case *rdf.Literal:
 		return term.String()
-	case *rdf2go.BlankNode:
+	case *rdf.BlankNode:
 		return term.String()
 	}
 
 	return ""
 }
 
-func serializeTurtle(g *rdf2go.Graph, w io.Writer) error {
+func serializeTurtle(g *rdf.Graph, w io.Writer) error {
 	var err error
 
-	triplesBySubject := make(map[string][]*rdf2go.Triple)
+	triplesBySubject := make(map[string][]*rdf.Triple)
 
 	for triple := range g.IterTriples() {
 		s := encodeTerm(triple.Subject)

--- a/ikuzo/service/x/bulk/parser_test.go
+++ b/ikuzo/service/x/bulk/parser_test.go
@@ -1,0 +1,40 @@
+package bulk
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kiivihal/rdf2go"
+	"github.com/matryer/is"
+)
+
+func TestSerializeTurtle(t *testing.T) {
+	is := is.New(t)
+
+	g := rdf2go.NewGraph("")
+	g.AddTriple(
+		rdf2go.NewResource("urn:subject"),
+		rdf2go.NewResource("http://purl.org/dc/elements/1.1/subject"),
+		rdf2go.NewLiteral("hello"),
+	)
+	g.AddTriple(
+		rdf2go.NewResource("urn:subject"),
+		rdf2go.NewResource("http://www.europeana.eu/schemas/edm/hasView"),
+		rdf2go.NewResource("urn:private/123"),
+	)
+	g.AddTriple(
+		rdf2go.NewResource("urn:private/123"),
+		rdf2go.NewResource("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+		rdf2go.NewLiteral("http://www.europeana.eu/schemas/edm/WebResource"),
+	)
+
+	is.Equal(g.Len(), 3)
+
+	var buf bytes.Buffer
+	err := serializeTurtle(g, &buf)
+	is.NoErr(err)
+
+	rdf := buf.String()
+	is.True(!strings.Contains(rdf, "urn:private/")) // serialized rdf should not contain urn:private
+}


### PR DESCRIPTION
Objects or Subjects that start with '<urn:private/' must not be inserted
in the SPARQL endpoint.