### PR TITLE
hub3: enable droporphans of lowercase 'findingaid' tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,7 @@
 - Show all EAD unittitles in tree.Label [[GH-110]](https://github.com/delving/hub3/pull/110)
 - Prevent redirect loop with invalid 'inventoryID' in tree API [[GH-112]](https://github.com/delving/hub3/pull/112)
 - Prevent 404 when call is made to /ead/tree without "q" parameter [[GH-114]](https://github.com/delving/hub3/pull/114)
-
-
+- Drop orphans with lowercase 'findingaid' tag [[GH-124]](https://github.com/delving/hub3/pull/124)
 
 ### Removed
 

--- a/ikuzo/service/x/index/service.go
+++ b/ikuzo/service/x/index/service.go
@@ -210,7 +210,7 @@ func (s *Service) dropOrphanGroup(orgID, datasetID string, revision *domainpb.Re
 	s.runPosthooks(orgID, datasetID, revision)
 
 	tags := elastic.NewBoolQuery()
-	for _, tag := range []string{"findingAid", "mets", "nt"} {
+	for _, tag := range []string{"findingAid", "findingaid", "mets", "nt"} {
 		tags = tags.Should(elastic.NewTermQuery("meta.tags", tag))
 	}
 


### PR DESCRIPTION
In some cases this caused the findingAid object not to be dropped from the index.