### PR TITLE
hub3: private filtering in bulk-service produced invalid RDF.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Prevent redirect loop with invalid 'inventoryID' in tree API [[GH-112]](https://github.com/delving/hub3/pull/112)
 - Prevent 404 when call is made to /ead/tree without "q" parameter [[GH-114]](https://github.com/delving/hub3/pull/114)
 - Drop orphans with lowercase 'findingaid' tag [[GH-124]](https://github.com/delving/hub3/pull/124)
+- Bulk index service sparql-update private filter produces invalid RDF [[GH-125]](https://github.com/delving/hub3/pull/125)
 
 ### Removed
 

--- a/ikuzo/service/x/bulk/parser_test.go
+++ b/ikuzo/service/x/bulk/parser_test.go
@@ -37,4 +37,6 @@ func TestSerializeTurtle(t *testing.T) {
 
 	rdf := buf.String()
 	is.True(!strings.Contains(rdf, "urn:private/")) // serialized rdf should not contain urn:private
+	t.Logf("rdf: %s", rdf)
+	is.True(strings.HasSuffix(rdf, " .\n"))
 }


### PR DESCRIPTION
The 'urn:private/' filtering could produce invalid RDF in some case.

Also added support for producing NTriples output for the SPARQL update.