### PR TITLE
hub3: imageproxy should return 404 when remote resource is not found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Prevent redirect loop with invalid 'inventoryID' in tree API [[GH-112]](https://github.com/delving/hub3/pull/112)
 - Prevent 404 when call is made to /ead/tree without "q" parameter [[GH-114]](https://github.com/delving/hub3/pull/114)
 - Drop orphans with lowercase 'findingaid' tag [[GH-124]](https://github.com/delving/hub3/pull/124)
+- Return 404 from imageproxy when remote resource is not found [[GH-127]](https://github.com/delving/hub3/pull/127)
 
 ### Removed
 

--- a/ikuzo/service/x/imageproxy/handle_proxy_request.go
+++ b/ikuzo/service/x/imageproxy/handle_proxy_request.go
@@ -2,6 +2,7 @@ package imageproxy
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"html"
 	"io"
@@ -107,6 +108,12 @@ func (s *Service) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 	err = s.Do(r.Context(), req, &buf)
 	if err != nil {
 		s.log.Error().Err(err).Str("url", req.SourceURL).Msg("unable to make proxy request")
+
+		if errors.Is(err, ErrRemoteResourceNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return

--- a/ikuzo/service/x/imageproxy/service.go
+++ b/ikuzo/service/x/imageproxy/service.go
@@ -33,6 +33,8 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 )
 
+var ErrRemoteResourceNotFound = errors.New("remote resource not found")
+
 // var _ domain.Service = (*Service)(nil)
 
 type Service struct {
@@ -257,11 +259,18 @@ func (s *Service) storeSource(req *Request) error {
 	}
 
 	resp, err := s.client.Do(proxyRequest)
-	if err != nil || resp.StatusCode != http.StatusOK {
+	if err != nil {
 		s.log.Error().Err(err).Str("url", req.SourceURL).Msg("unable to make remote request")
 		s.m.IncRemoteRequestError()
 
 		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		s.log.Error().Err(err).Int("status_code", resp.StatusCode).Str("url", req.SourceURL).Msg("retrieve object")
+		s.m.IncRemoteRequestError()
+
+		return fmt.Errorf("status_code: %d; %w", resp.StatusCode, ErrRemoteResourceNotFound)
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
The current implementation return 200 unless an explicit error is thrown. This pull-request returns an 404 when the remote resource cannot be retrieved.