### PR TITLE
hub3: added support for allowed mimetypes to imageproxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Ignore private resources in bulk sparql export [[GH-123]](https://github.com/delving/hub3/pull/123)
 - processDigitalIfMissing processes mets if missing [[GH-126]](https://github.com/delving/hub3/pull/126)
 - Cache cleaning work for imageproxy service [[GH-119]](https://github.com/delving/hub3/pull/119)
+- Support for allowed mimetypes to imageproxy service [[GH-130]](https://github.com/delving/hub3/pull/130)
 
 
 ## Changed 

--- a/hub3.toml
+++ b/hub3.toml
@@ -173,7 +173,14 @@ referrer = []
 # a list of allowed remote hosts. If empty everything is allowed
 # allowList = ["service.archief.nl", "service.test.archief.nl", "service.acpt.archief.nl"]
 # a list of refused patterns in cachable urls
-refuseList = []
+refuseList = ["127.0.0.1", "0.0.0.0", "localhost"]
+# allowedMimeTypes that can be proxied
+allowedMimeTypes = [
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/tiff",
+]
 # lruCacheSize 
 lruCacheSize = 1000
 # image can be resized; requires libvips to be installed

--- a/ikuzo/ikuzoctl/cmd/config/imageproxy.go
+++ b/ikuzo/ikuzoctl/cmd/config/imageproxy.go
@@ -22,16 +22,17 @@ import (
 )
 
 type ImageProxy struct {
-	Enabled         bool
-	CacheDir        string
-	MaxSizeCacheDir int
-	ProxyPrefix     string
-	Timeout         int
-	ProxyReferrer   []string
-	RefuseList      []string
-	AllowList       []string
-	LruCacheSize    int
-	EnableResize    bool
+	Enabled          bool
+	CacheDir         string
+	MaxSizeCacheDir  int
+	ProxyPrefix      string
+	Timeout          int
+	ProxyReferrer    []string
+	RefuseList       []string
+	AllowList        []string
+	AllowedMimeTypes []string
+	LruCacheSize     int
+	EnableResize     bool
 }
 
 func (ip *ImageProxy) AddOptions(cfg *Config) error {
@@ -50,6 +51,7 @@ func (ip *ImageProxy) AddOptions(cfg *Config) error {
 		imageproxy.SetLruCacheSize(ip.LruCacheSize),
 		imageproxy.SetEnableResize(ip.EnableResize),
 		imageproxy.SetLogger(cfg.logger.Logger),
+		imageproxy.SetAllowedMimeTypes(ip.AllowedMimeTypes),
 	)
 	if err != nil {
 		return err

--- a/ikuzo/service/x/imageproxy/options.go
+++ b/ikuzo/service/x/imageproxy/options.go
@@ -71,6 +71,13 @@ func SetAllowList(allowList []string) Option {
 	}
 }
 
+func SetAllowedMimeTypes(allowedMimeTypes []string) Option {
+	return func(s *Service) error {
+		s.allowedMimeTypes = allowedMimeTypes
+		return nil
+	}
+}
+
 func SetProxyPrefix(prefix string) Option {
 	return func(s *Service) error {
 		s.proxyPrefix = prefix


### PR DESCRIPTION
By default all mime-types are allowed. This pull-requests add functionality to filter based on allowed mime-types. An example config could be:

```toml
allowedMimeTypes = [
    "image/jpeg",
    "image/png",
    "image/gif",
    "image/tiff",
]
```