### PR TITLE
Limit SPARQL proxy queries to a maximum of 1000 results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - hub3: refactor elasticsearch storage into driver package [9949b8a7](https://github.com/delving/hub3/commit/9949b8a7)
 - hub3: LDF always returns 'text/turtle' [82f2e6cf](https://github.com/delving/hub3/commit/82f2e6cf)
 - updated github configuration  [[GH-133]](https://github.com/delving/hub3/pull/133)
+- limit SPARQL proxy qureies to a maximum of 1000 results [[GH-148]](https://github.com/delving/hub3/pull/148)
 
 ## Removed
  

--- a/hub3.toml
+++ b/hub3.toml
@@ -113,7 +113,7 @@ consoleLogger = true
 # Enable storing of the RDF records in the triple store specified in sparqlUpdatePath (default: false)
 rdfStoreEnabled = false
 # the fully qualified URL including the port
-sparqlHost = "http://localhost:3030"
+sparqlHost = "http://localhost:3033"
 # the path to the SPARQL endpoint. A '%s' can be inserted in the path to be replaced with the orgId.
 #sparqlPath = "/bigdata/namespace/%s/sparql"
 sparqlPath = "/%s/sparql"

--- a/hub3/server/http/handlers/sparql.go
+++ b/hub3/server/http/handlers/sparql.go
@@ -35,7 +35,7 @@ func RegisterSparql(r chi.Router) {
 	r.Post("/sparql", sparqlProxy)
 }
 
-var limitExp = regexp.MustCompile(`(?im) limit (\d*)`)
+var limitExp = regexp.MustCompile(`(?im)\slimit\s*(\d*)`)
 
 func ensureSparqlLimit(query string) (string, error) {
 	matches := limitExp.FindAllStringSubmatch(query, -1)
@@ -43,14 +43,15 @@ func ensureSparqlLimit(query string) (string, error) {
 		return fmt.Sprintf("%s LIMIT 25", query), nil
 	}
 
-	last := matches[len(matches)-1]
-	number, err := strconv.ParseInt(last[1], 10, 0)
-	if err != nil {
-		return "", fmt.Errorf("limit attribute %q is not a valid number", last[1])
-	}
+	for _, m := range matches {
+		number, err := strconv.ParseInt(m[1], 10, 0)
+		if err != nil {
+			return "", fmt.Errorf("limit attribute %q is not a valid number", m[1])
+		}
 
-	if number > 1000 {
-		return "", fmt.Errorf("sparql limit is not allowed to be greater than 1000")
+		if number > 1000 {
+			return "", fmt.Errorf("sparql limit is not allowed to be greater than 1000")
+		}
 	}
 
 	return query, nil

--- a/hub3/server/http/handlers/sparql.go
+++ b/hub3/server/http/handlers/sparql.go
@@ -16,9 +16,11 @@ package handlers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,14 +35,36 @@ func RegisterSparql(r chi.Router) {
 	r.Post("/sparql", sparqlProxy)
 }
 
+var limitExp = regexp.MustCompile(`(?im) limit (\d*)`)
+
+func ensureSparqlLimit(query string) (string, error) {
+	matches := limitExp.FindAllStringSubmatch(query, -1)
+	if len(matches) == 0 || matches == nil {
+		return fmt.Sprintf("%s LIMIT 25", query), nil
+	}
+
+	last := matches[len(matches)-1]
+	number, err := strconv.ParseInt(last[1], 10, 0)
+	if err != nil {
+		return "", fmt.Errorf("limit attribute %q is not a valid number", last[1])
+	}
+
+	if number > 1000 {
+		return "", fmt.Errorf("sparql limit is not allowed to be greater than 1000")
+	}
+
+	return query, nil
+}
+
 func sparqlProxy(w http.ResponseWriter, r *http.Request) {
 	if !c.Config.RDF.SparqlEnabled {
 		log.Printf("sparql is disabled\n")
 		render.JSON(w, r, &ErrorMessage{"not enabled", ""})
 		return
 	}
+
 	var query string
-	log.Print(r.Method)
+
 	switch r.Method {
 	case http.MethodGet:
 		query = r.URL.Query().Get("query")
@@ -53,9 +77,13 @@ func sparqlProxy(w http.ResponseWriter, r *http.Request) {
 		render.JSON(w, r, &ErrorMessage{"Bad Request", "a value in the query param is required."})
 		return
 	}
-	if !strings.Contains(strings.ToLower(query), "limit ") {
-		query = fmt.Sprintf("%s LIMIT 25", query)
+
+	query, err := ensureSparqlLimit(query)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
+
 	// log.Println(query)
 	orgID := domain.GetOrganizationID(r)
 	resp, statusCode, contentType, err := runSparqlQuery(orgID.String(), query)
@@ -67,7 +95,7 @@ func sparqlProxy(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", contentType)
 	_, err = w.Write(resp)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("%v", err), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	render.Status(r, statusCode)
@@ -77,7 +105,7 @@ func sparqlProxy(w http.ResponseWriter, r *http.Request) {
 // runSparqlQuery sends a SPARQL query to the SPARQL-endpoint specified in the configuration
 func runSparqlQuery(orgID, query string) (body []byte, statusCode int, contentType string, err error) {
 	log.Printf("Sparql Query: %s", query)
-	req, err := http.NewRequest("Get", c.Config.GetSparqlEndpoint(orgID, ""), nil)
+	req, err := http.NewRequest("Get", c.Config.GetSparqlEndpoint(orgID, ""), http.NoBody)
 	if err != nil {
 		log.Printf("Unable to create sparql request %s", err)
 	}
@@ -99,12 +127,13 @@ func runSparqlQuery(orgID, query string) (body []byte, statusCode int, contentTy
 		return
 	}
 	defer resp.Body.Close()
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Unable to read the response body with error: %s", err)
 		return
 	}
 	statusCode = resp.StatusCode
 	contentType = resp.Header.Get("Content-Type")
-	return
+
+	return body, statusCode, contentType, err
 }

--- a/hub3/server/http/handlers/sparql_test.go
+++ b/hub3/server/http/handlers/sparql_test.go
@@ -39,7 +39,36 @@ func Test_ensureSparqlLimit(t *testing.T) {
 			"with limit badly formatted limit",
 			args{query: "select * where {?s ?p ?o} LIMIT A15AA"},
 			"",
-			false,
+			true,
+		},
+		{
+			"comment hack for limit",
+			args{query: `select ?person_id ?place_of_birth ?other_person_id
+			LIMIT     1200 # LIMIT 900`},
+			"",
+			true,
+		},
+		{
+			"check all subqueries",
+			args{query: `
+				select ?person_id ?place_of_birth ?other_person_id
+				where {
+					?person_id fb:type.object.type fb:people.person .
+					?person_id fb:people.person.place_of_birth ?place_of_birth_id .
+					?place_of_birth_id fb:type.object.name ?place_of_birth .
+					{
+					select  ?other_person_id
+					where {
+					?place_of_birth_id fb:location.location.people_born_here ?other_person_id .
+					}
+					LIMIT 1001
+					}
+					FILTER (langMatches(lang(?place_of_birth),"en"))
+				}
+				LIMIT 3
+			`},
+			"",
+			true,
 		},
 	}
 

--- a/hub3/server/http/handlers/sparql_test.go
+++ b/hub3/server/http/handlers/sparql_test.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_ensureSparqlLimit(t *testing.T) {
+	type args struct {
+		query string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			"no limit in query",
+			args{query: "select * where {?s ?p ?o}"},
+			"select * where {?s ?p ?o} LIMIT 25",
+			false,
+		},
+		{
+			"with limit in query",
+			args{query: "select * where {?s ?p ?o} LIMIT 100"},
+			"select * where {?s ?p ?o} LIMIT 100",
+			false,
+		},
+		{
+			"with limit in query",
+			args{query: "select * where {?s ?p ?o} LIMIT 1500"},
+			"",
+			true,
+		},
+		{
+			"with limit badly formatted limit",
+			args{query: "select * where {?s ?p ?o} LIMIT A15AA"},
+			"",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ensureSparqlLimit(tt.args.query)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ensureSparqlLimit() %s; error = %v, wantErr %v", tt.name, err, tt.wantErr)
+				return
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ensureSparqlLimit() %s; mismatch (-want +got):\n%s", tt.name, diff)
+			}
+		})
+	}
+}

--- a/ikuzo/domain/organization.go
+++ b/ikuzo/domain/organization.go
@@ -134,10 +134,9 @@ func (o *Organization) NewDatasetURI(spec string) string {
 //
 // This orgID is set by middleware and available for each request
 func GetOrganizationID(r *http.Request) OrganizationID {
-	orgID := r.Context().Value(orgIDKey{})
-	if orgID != nil {
-		id, _ := NewOrganizationID(orgID.(string))
-		return id
+	org, ok := GetOrganization(r)
+	if ok {
+		return org.ID
 	}
 
 	return ""

--- a/ikuzo/ikuzoctl/cmd/serve.go
+++ b/ikuzo/ikuzoctl/cmd/serve.go
@@ -68,6 +68,7 @@ func serve() {
 			handlers.RegisterEAD,
 			handlers.RegisterLinkedDataFragments,
 			handlers.RegisterLOD,
+			handlers.RegisterSparql,
 		),
 		ikuzo.SetEnableLegacyConfig(cfgFile),
 		ikuzo.SetStaticFS(staticFS),


### PR DESCRIPTION
When no limit is given a default of 25 is added to the query. When
the size of the limit is larger than 1000, an error is returned.