### PR TITLE
Added graph-store endpoint to upload for example ontologies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - hub3: added dedicated esproxy service. [10f521cf](https://github.com/delving/hub3/commit/10f521cf)
 - hub3: added sitemap package [80c4d3be](https://github.com/delving/hub3/commit/80c4d3be)
 - hub3: initial version of postgresql service. [41309cb0](https://github.com/delving/hub3/commit/41309cb0)
+- added graph-store protocol endpoint for uploading RDF ontologies  [[GH_149]](https://github.com/delving/hub3/pull/149)
 
 ### Changed
 

--- a/hub3/server/http/handlers/sparql.go
+++ b/hub3/server/http/handlers/sparql.go
@@ -33,6 +33,9 @@ import (
 func RegisterSparql(r chi.Router) {
 	r.Get("/sparql", sparqlProxy)
 	r.Post("/sparql", sparqlProxy)
+	r.Put("/api/rdf/graph-store", graphStoreUpdate)
+	r.Delete("/api/rdf/graph-store", graphStoreDelete)
+	r.Post("/api/rdf/graph-store/delete", graphStoreDelete)
 }
 
 var limitExp = regexp.MustCompile(`(?im)\slimit\s*(\d*)`)
@@ -85,7 +88,6 @@ func sparqlProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// log.Println(query)
 	orgID := domain.GetOrganizationID(r)
 	resp, statusCode, contentType, err := runSparqlQuery(orgID.String(), query)
 	if err != nil {
@@ -103,18 +105,7 @@ func sparqlProxy(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
-// runSparqlQuery sends a SPARQL query to the SPARQL-endpoint specified in the configuration
-func runSparqlQuery(orgID, query string) (body []byte, statusCode int, contentType string, err error) {
-	log.Printf("Sparql Query: %s", query)
-	req, err := http.NewRequest("Get", c.Config.GetSparqlEndpoint(orgID, ""), http.NoBody)
-	if err != nil {
-		log.Printf("Unable to create sparql request %s", err)
-	}
-	req.Header.Set("Accept", "application/sparql-results+json")
-	q := req.URL.Query()
-	q.Add("query", query)
-	req.URL.RawQuery = q.Encode()
-
+func makeSparqlRequest(req *http.Request) (body []byte, statusCode int, contentType string, err error) {
 	netClient := &http.Client{
 		Timeout: time.Second * 10,
 	}
@@ -137,4 +128,132 @@ func runSparqlQuery(orgID, query string) (body []byte, statusCode int, contentTy
 	contentType = resp.Header.Get("Content-Type")
 
 	return body, statusCode, contentType, err
+}
+
+// runSparqlQuery sends a SPARQL query to the SPARQL-endpoint specified in the configuration
+func runSparqlQuery(orgID, query string) (body []byte, statusCode int, contentType string, err error) {
+	log.Printf("Sparql Query: %s", query)
+	req, err := http.NewRequest("Get", c.Config.GetSparqlEndpoint(orgID, ""), http.NoBody)
+	if err != nil {
+		log.Printf("Unable to create sparql request %s", err)
+		return
+	}
+	req.Header.Set("Accept", "application/sparql-results+json")
+	q := req.URL.Query()
+	q.Add("query", query)
+	req.URL.RawQuery = q.Encode()
+
+	return makeSparqlRequest(req)
+}
+
+func graphStoreDelete(w http.ResponseWriter, r *http.Request) {
+	if !c.Config.RDF.SparqlEnabled {
+		log.Printf("sparql is disabled\n")
+		render.JSON(w, r, &ErrorMessage{"not enabled", ""})
+		return
+	}
+
+	var graphName string
+
+	switch r.Method {
+	case http.MethodPost:
+		graphName = r.FormValue("graph")
+	case http.MethodDelete:
+		graphName = r.URL.Query().Get("graph")
+	}
+
+	if graphName == "" {
+		render.JSON(w, r, &ErrorMessage{"invalid graph form value", ""})
+		return
+	}
+
+	orgID := domain.GetOrganizationID(r)
+	resp, statusCode, contentType, err := runGraphStoreDelete(orgID.String(), graphName)
+	if err != nil {
+		render.Status(r, http.StatusBadRequest)
+		render.PlainText(w, r, string(resp))
+		return
+	}
+	w.Header().Set("Content-Type", contentType)
+	_, err = w.Write(resp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	render.Status(r, statusCode)
+	return
+}
+
+func graphStoreUpdate(w http.ResponseWriter, r *http.Request) {
+	if !c.Config.RDF.SparqlEnabled {
+		log.Printf("sparql is disabled\n")
+		render.JSON(w, r, &ErrorMessage{"not enabled", ""})
+		return
+	}
+
+	in, _, err := r.FormFile("rdf")
+	if err != nil {
+		http.Error(w, "cannot find ead form file", http.StatusBadRequest)
+		return
+	}
+
+	defer in.Close()
+
+	// cleanup upload
+	defer func() {
+		err = r.MultipartForm.RemoveAll()
+	}()
+
+	graphName := r.FormValue("graph")
+	if graphName == "" {
+		render.JSON(w, r, &ErrorMessage{"invalid graph form value", ""})
+		return
+	}
+
+	fileContentType := r.FormValue("content-type")
+
+	orgID := domain.GetOrganizationID(r)
+	resp, statusCode, contentType, err := runGraphStoreQuery(orgID.String(), graphName, fileContentType, in)
+	if err != nil {
+		render.Status(r, http.StatusBadRequest)
+		render.PlainText(w, r, string(resp))
+		return
+	}
+	w.Header().Set("Content-Type", contentType)
+	_, err = w.Write(resp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	render.Status(r, statusCode)
+	return
+}
+
+// runGraphStoreQuery sends a GraphStore request to the SPARQL-endpoint specified in the configuration
+func runGraphStoreQuery(orgID, graphName, inContentType string, in io.Reader) (body []byte, statusCode int, contentType string, err error) {
+	req, err := http.NewRequest(http.MethodPut, c.Config.GetGraphStoreEndpoint(orgID, ""), in)
+	if err != nil {
+		log.Printf("Unable to create sparql request %s", err)
+		return
+	}
+	req.Header.Add("Content-Type", inContentType)
+	params := req.URL.Query()
+	params.Set("graph", graphName)
+	req.URL.RawQuery = params.Encode()
+
+	return makeSparqlRequest(req)
+}
+
+// runGraphStoreQuery sends a GraphStore request to the SPARQL-endpoint specified in the configuration
+func runGraphStoreDelete(orgID, graphName string) (body []byte, statusCode int, contentType string, err error) {
+	req, err := http.NewRequest(http.MethodDelete, c.Config.GetGraphStoreEndpoint(orgID, ""), http.NoBody)
+	if err != nil {
+		log.Printf("Unable to create sparql request %s", err)
+		return
+	}
+	params := req.URL.Query()
+	params.Set("graph", graphName)
+	req.URL.RawQuery = params.Encode()
+
+	return makeSparqlRequest(req)
 }

--- a/hub3/server/http/handlers/sparql.go
+++ b/hub3/server/http/handlers/sparql.go
@@ -109,6 +109,7 @@ func makeSparqlRequest(req *http.Request) (body []byte, statusCode int, contentT
 	netClient := &http.Client{
 		Timeout: time.Second * 10,
 	}
+
 	resp, err := netClient.Do(req)
 	if err != nil {
 		log.Printf("Error in sparql query: %s", err)
@@ -132,8 +133,7 @@ func makeSparqlRequest(req *http.Request) (body []byte, statusCode int, contentT
 
 // runSparqlQuery sends a SPARQL query to the SPARQL-endpoint specified in the configuration
 func runSparqlQuery(orgID, query string) (body []byte, statusCode int, contentType string, err error) {
-	log.Printf("Sparql Query: %s", query)
-	req, err := http.NewRequest("Get", c.Config.GetSparqlEndpoint(orgID, ""), http.NoBody)
+	req, err := http.NewRequest("POST", c.Config.GetSparqlEndpoint(orgID, ""), http.NoBody)
 	if err != nil {
 		log.Printf("Unable to create sparql request %s", err)
 		return


### PR DESCRIPTION
The endpoint supports both uploads and deletes via the GraphStore
protocol. In the future this endpoint should be protected with an API
key.