### PR TITLE
Added sparql-based lod resolver for '/id' and '/resource' uris.

### DIFF
--- a/hub3/server/http/handlers/lod.go
+++ b/hub3/server/http/handlers/lod.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 
 	c "github.com/delving/hub3/config"
@@ -26,6 +27,13 @@ import (
 	"github.com/delving/hub3/ikuzo/domain"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
+)
+
+const (
+	idPrefix       = "id"
+	resourcePrefix = "resource"
+	docPrefix      = "doc"
+	dataPrefix     = "data"
 )
 
 var lodPathRoute = "/{path:%s}/*"
@@ -40,15 +48,137 @@ func RegisterLOD(r chi.Router) {
 			// fmt.Sprintf(lodPathRoute, config.Config.LOD.HTML), RenderLODResource)
 			fmt.Sprintf(lodPathRoute, c.Config.LOD.HTML), func(w http.ResponseWriter, r *http.Request) {
 				render.PlainText(w, r, `{"type": "rdf html endpoint"}`)
-				return
 			})
 	}
+
+	redirects := []string{
+		idPrefix, resourcePrefix, docPrefix, dataPrefix,
+	}
+
+	for _, prefix := range redirects {
+		r.Get(fmt.Sprintf("/%s/*", prefix), lodRedirect)
+	}
+
+	r.Get("/resource", lodResolver())
+}
+
+func rewriteLodPrefixes(path string) string {
+	parts := strings.Split(path, "/")
+	switch parts[1] {
+	case idPrefix:
+		parts[1] = docPrefix
+	case resourcePrefix:
+		parts[1] = dataPrefix
+	}
+
+	return strings.Join(parts, "/")
+}
+
+func getResolveURL(r *http.Request) string {
+	path := r.URL.Path
+	hostDomain := c.Config.RDF.BaseURL
+
+	return fmt.Sprintf("%s%s", hostDomain, rewriteLodPrefixes(path))
+}
+
+func lodRedirect(w http.ResponseWriter, r *http.Request) {
+	sourceURI := getResolveURL(r)
+	resolveURI := fmt.Sprintf("/resource?uri=%s", sourceURI)
+	http.Redirect(w, r, resolveURI, http.StatusNotFound)
+}
+
+func getSparqlSubject(iri string) (string, error) {
+	uri, err := url.Parse(iri)
+	if err != nil {
+		return "", err
+	}
+
+	parts := strings.Split(uri.Path, "/")
+	switch parts[1] {
+	case docPrefix:
+		parts[1] = idPrefix
+	case dataPrefix:
+		parts[1] = resourcePrefix
+	}
+
+	return fmt.Sprintf("%s://%s%s", uri.Scheme, uri.Host, strings.Join(parts, "/")), nil
+}
+
+func lodResolver() http.HandlerFunc {
+	acceptedLodFormats := map[string]string{
+		"turtle":    "text/turtle",
+		"json-ld":   "application/ld+json",
+		"n-triples": "application/n-triples",
+		"n-quads":   "application/n-quads",
+		"trig":      "application/trig",
+		"rdfxml":    "application/rdf+xml",
+	}
+
+	acceptHeaders := []string{}
+	acceptedMimeTypes := map[string]string{}
+
+	for queryParam, mimetype := range acceptedLodFormats {
+		acceptHeaders = append(acceptHeaders, mimetype)
+		acceptedMimeTypes[mimetype] = queryParam
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		iri, err := getSparqlSubject(r.URL.Query().Get("uri"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		acceptMimeType := "text/turtle"
+
+		if r.URL.Query().Has("format") {
+			format := r.URL.Query().Get("format")
+			mimetype, ok := acceptedLodFormats[format]
+			if ok {
+				acceptMimeType = mimetype
+			}
+		} else {
+			accept := r.Header.Get("Accept")
+			_, ok := acceptedMimeTypes[accept]
+			if ok {
+				acceptMimeType = accept
+			}
+		}
+
+		orgID := domain.GetOrganizationID(r)
+		query := fmt.Sprintf("describe <%s>", iri)
+
+		resp, statusCode, contentType, err := runSparqlQuery(orgID.String(), query, acceptMimeType)
+		if err != nil {
+			render.Status(r, http.StatusBadRequest)
+			render.PlainText(w, r, string(resp))
+			return
+		}
+		w.Header().Set(contentTypeKey, contentType)
+
+		formats := []string{}
+		for _, f := range acceptedLodFormats {
+			formats = append(formats, f)
+		}
+
+		w.Header().Add("Accept", strings.Join(formats, ", "))
+
+		_, err = w.Write(resp)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// TODO(kiivihal): add support for 404 not found. Now always 200 is returned
+		render.Status(r, statusCode)
+	})
 }
 
 // RenderLODResource returns a list of matching fragments
 // for a LOD resource. This mimicks a SPARQL describe request
 func RenderLODResource(w http.ResponseWriter, r *http.Request) {
 	lodKey := r.URL.Path
+
 	if c.Config.LOD.SingleEndpoint == "" {
 		resourcePrefix := fmt.Sprintf("/%s", c.Config.LOD.Resource)
 		if strings.HasPrefix(lodKey, resourcePrefix) {
@@ -69,7 +199,6 @@ func RenderLODResource(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		lodKey = strings.TrimSuffix(lodKey, ".nt")
-
 	}
 
 	orgID := domain.GetOrganizationID(r)
@@ -79,6 +208,7 @@ func RenderLODResource(w http.ResponseWriter, r *http.Request) {
 	frags, _, err := fr.Find(r.Context(), index.ESClient())
 	if err != nil || len(frags) == 0 {
 		w.WriteHeader(http.StatusNotFound)
+
 		if err != nil {
 			log.Printf("Unable to list fragments because of: %s", err)
 			return
@@ -87,6 +217,7 @@ func RenderLODResource(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Unable to find fragments")
 		return
 	}
+
 	w.Header().Set("Content-Type", "text/n-triples")
 	for _, frag := range frags {
 		fmt.Fprintln(w, frag.Triple)

--- a/hub3/server/http/handlers/lod_test.go
+++ b/hub3/server/http/handlers/lod_test.go
@@ -1,0 +1,68 @@
+// Copyright © 2017 Delving B.V. <info@delving.eu>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/delving/hub3/config"
+)
+
+func Test_getResolveURL(t *testing.T) {
+	config.Config.RDF.BaseURL = "http://data.hub3.org"
+
+	type args struct {
+		url string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"simple id url",
+			args{"http://localhost:3000/id/123"},
+			"http://data.hub3.org/doc/123",
+		},
+		{
+			"simple doc url",
+			args{"http://localhost:3000/doc/123"},
+			"http://data.hub3.org/doc/123",
+		},
+		{
+			"query params ignored",
+			args{"http://localhost:3000/id/123?id=bla"},
+			"http://data.hub3.org/doc/123",
+		},
+		{
+			"simple resource url",
+			args{"http://localhost:3000/resource/document/dataset/123"},
+			"http://data.hub3.org/data/document/dataset/123",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		r, _ := http.NewRequest(http.MethodGet, tt.args.url, http.NoBody)
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getResolveURL(r); got != tt.want {
+				t.Errorf("getResolveURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/hub3/server/http/handlers/sparql.go
+++ b/hub3/server/http/handlers/sparql.go
@@ -95,7 +95,7 @@ func sparqlProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	orgID := domain.GetOrganizationID(r)
-	resp, statusCode, contentType, err := runSparqlQuery(orgID.String(), query)
+	resp, statusCode, contentType, err := runSparqlQuery(orgID.String(), query, "application/sparql-results+json")
 	if err != nil {
 		render.Status(r, http.StatusBadRequest)
 		render.PlainText(w, r, string(resp))
@@ -138,13 +138,13 @@ func makeSparqlRequest(req *http.Request) (body []byte, statusCode int, contentT
 }
 
 // runSparqlQuery sends a SPARQL query to the SPARQL-endpoint specified in the configuration
-func runSparqlQuery(orgID, query string) (body []byte, statusCode int, contentType string, err error) {
+func runSparqlQuery(orgID, query, acceptHeader string) (body []byte, statusCode int, contentType string, err error) {
 	req, err := http.NewRequest("POST", c.Config.GetSparqlEndpoint(orgID, ""), http.NoBody)
 	if err != nil {
 		log.Printf("%s", fmt.Errorf("%s; %w ", ErrInvalidSparqlRequest, err))
 		return
 	}
-	req.Header.Set("Accept", "application/sparql-results+json")
+	req.Header.Set("Accept", acceptHeader)
 	q := req.URL.Query()
 	q.Add("query", query)
 	req.URL.RawQuery = q.Encode()

--- a/ikuzo/ikuzoctl/cmd/serve.go
+++ b/ikuzo/ikuzoctl/cmd/serve.go
@@ -65,7 +65,6 @@ func serve() {
 			handlers.RegisterDatasets,
 			handlers.RegisterEAD,
 			handlers.RegisterSearch,
-			handlers.RegisterEAD,
 			handlers.RegisterLinkedDataFragments,
 			handlers.RegisterLOD,
 			handlers.RegisterSparql,


### PR DESCRIPTION
Requests where the relative path starts with '/id' and '/doc' will be rewritten using the RDFbaseURL to a resource endpoint. The resource endpoint queries the SPARQL endpoint for the resource. Via a '?format' parameter or the accept header various different RDF serializations can be requested. The following are supported:

```go
	acceptedLodFormats := map[string]string{
		"turtle":    "text/turtle",
		"json-ld":   "application/ld+json",
		"n-triples": "application/n-triples",
		"n-quads":   "application/n-quads",
		"trig":      "application/trig",
		"rdfxml":    "application/rdf+xml",
	}
```

The keys are accepted by the '?format' parameter. The values are the accepted mimetypes.