### PR TITLE
Enable default orgID as fallback.

### DIFF
--- a/ikuzo/domain/errors.go
+++ b/ikuzo/domain/errors.go
@@ -1,0 +1,14 @@
+package domain
+
+import "errors"
+
+// errors
+var (
+	ErrIDTooLong          = errors.New("identifier is too long")
+	ErrIDNotLowercase     = errors.New("uppercase not allowed in identifier")
+	ErrIDInvalidCharacter = errors.New("only letters and numbers are allowed in organization")
+	ErrIDCannotBeEmpty    = errors.New("empty string is not a valid identifier")
+	ErrIDExists           = errors.New("identifier already exists")
+	ErrOrgNotFound        = errors.New("organization not found")
+	ErrHubIDInvalid       = errors.New("HubID strings is invalid")
+)

--- a/ikuzo/domain/hub_id.go
+++ b/ikuzo/domain/hub_id.go
@@ -1,0 +1,35 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+)
+
+type HubID struct {
+	OrgID     string
+	DatasetID string
+	LocalID   string
+}
+
+func NewHubID(input string) (HubID, error) {
+	parts := strings.SplitN(input, "_", 3)
+	if len(parts) != 3 {
+		return HubID{}, ErrHubIDInvalid
+	}
+
+	for _, v := range parts {
+		if v == "" {
+			return HubID{}, ErrHubIDInvalid
+		}
+	}
+
+	return HubID{
+		OrgID:     parts[0],
+		DatasetID: parts[1],
+		LocalID:   parts[2],
+	}, nil
+}
+
+func (h HubID) String() string {
+	return fmt.Sprintf("%s_%s_%s", h.OrgID, h.DatasetID, h.LocalID)
+}

--- a/ikuzo/domain/hub_id_test.go
+++ b/ikuzo/domain/hub_id_test.go
@@ -1,0 +1,59 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewHubID(t *testing.T) {
+	type args struct {
+		input string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    HubID
+		wantErr bool
+	}{
+		{
+			"valid",
+			args{input: "org_spec_123"},
+			HubID{OrgID: "org", DatasetID: "spec", LocalID: "123"},
+			false,
+		},
+		{
+			"invalid empty",
+			args{input: ""},
+			HubID{OrgID: "", DatasetID: "", LocalID: ""},
+			true,
+		},
+		{
+			"invalid missing id",
+			args{input: "org_spec"},
+			HubID{OrgID: "", DatasetID: "", LocalID: ""},
+			true,
+		},
+		{
+			"invalid missing id",
+			args{input: "org_spec_"},
+			HubID{OrgID: "", DatasetID: "", LocalID: ""},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewHubID(tt.args.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewHubID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("NewHubID() %s mismatch (-want +got):\n%s", tt.name, diff)
+			}
+		})
+	}
+}

--- a/ikuzo/domain/organization.go
+++ b/ikuzo/domain/organization.go
@@ -16,23 +16,12 @@ package domain
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"unicode"
 )
 
 type orgIDKey struct{}
-
-// errors
-var (
-	ErrIDTooLong          = errors.New("identifier is too long")
-	ErrIDNotLowercase     = errors.New("uppercase not allowed in identifier")
-	ErrIDInvalidCharacter = errors.New("only letters and numbers are allowed in organization")
-	ErrIDCannotBeEmpty    = errors.New("empty string is not a valid identifier")
-	ErrIDExists           = errors.New("identifier already exists")
-	ErrOrgNotFound        = errors.New("organization not found")
-)
 
 var (
 	// MaxLengthID the maximum length of an identifier

--- a/ikuzo/service/organization/middleware.go
+++ b/ikuzo/service/organization/middleware.go
@@ -40,12 +40,13 @@ func (s *Service) ResolveOrgByDomain(next http.Handler) http.Handler {
 
 		org, ok := domains[domain]
 		if !ok {
-			if defaultOrgID != nil {
+			if defaultOrgID == nil {
 				w.Header().Set("Content-Type", "text/plain")
 				w.WriteHeader(http.StatusNotFound)
 				w.Write([]byte("no organization available for this domain"))
 				return
 			}
+			org = defaultOrgID
 		}
 		// w.Header().Set("ORG-ID", org.RawID())
 		r = d.SetOrganization(r, org)

--- a/ikuzo/service/organization/organizationtests/middleware_test.go
+++ b/ikuzo/service/organization/organizationtests/middleware_test.go
@@ -21,7 +21,6 @@ func TestService_ResolveOrgByDomain(t *testing.T) {
 	r := chi.NewRouter()
 	r.Use(svc.ResolveOrgByDomain)
 	r.Get("/hi", func(w http.ResponseWriter, r *http.Request) {
-		// GetOrganizationID(r)
 		w.Header().Set("X-Test", "yes")
 		w.Write([]byte("bye"))
 	})
@@ -54,11 +53,8 @@ func TestService_ResolveOrgByDomain(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
-	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("should give badrequest, got; %d", resp.StatusCode)
-	}
 
-	// orgID, err := organization.GetOrganizationID(resp.Request)
-	// is.NoErr(err)
-	// is.Equal(orgID, "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("should give bad krequest, got; %d", resp.StatusCode)
+	}
 }


### PR DESCRIPTION
This allows one default to be set for many different urls. This should
only be used when there is only a single organization configured.