### PR TITLE
Add config option to ignore certain paths from request logging.

### DIFF
--- a/hub3.toml
+++ b/hub3.toml
@@ -140,6 +140,9 @@ sentryDSN = ""
 level = "debug"
 withCaller = true
 consoleLogger = true
+# "*" ignores all 404, paths ending with "*" are wildcards
+# all paths should start with a forward slash "*"
+exclude404Path = []
 
 [rdf]
 # Enable storing of the RDF records in the triple store specified in sparqlUpdatePath (default: false)

--- a/ikuzo/ikuzoctl/cmd/config/logging.go
+++ b/ikuzo/ikuzoctl/cmd/config/logging.go
@@ -25,12 +25,13 @@ import (
 )
 
 type Logging struct {
-	DevMode        bool   `json:"devmode"`
-	Level          string `json:"level"`
-	WithCaller     bool   `json:"withCaller"`
-	ConsoleLogger  bool   `json:"consoleLogger"`
-	ErrorFieldName string `json:"errorFieldName"`
-	SentryDSN      string `json:"sentryDSN"`
+	DevMode        bool     `json:"devmode"`
+	Level          string   `json:"level"`
+	WithCaller     bool     `json:"withCaller"`
+	ConsoleLogger  bool     `json:"consoleLogger"`
+	ErrorFieldName string   `json:"errorFieldName"`
+	SentryDSN      string   `json:"sentryDSN"`
+	Exclude404Path []string `json:"exclude404Path"`
 }
 
 func (l *Logging) AddOptions(cfg *Config) error {
@@ -46,6 +47,7 @@ func (l *Logging) AddOptions(cfg *Config) error {
 				r.Mount("/debug", mw.Profiler())
 			}),
 			ikuzo.SetEnableIntrospect(l.DevMode),
+			ikuzo.SetIgnore404Paths(l.Exclude404Path),
 		)
 	}
 

--- a/ikuzo/options.go
+++ b/ikuzo/options.go
@@ -214,3 +214,10 @@ func SetEnableSentry(dsn string) Option {
 		})
 	}
 }
+
+func SetIgnore404Paths(paths []string) Option {
+	return func(s *server) error {
+		s.ignore404Paths = paths
+		return nil
+	}
+}

--- a/ikuzo/server.go
+++ b/ikuzo/server.go
@@ -89,6 +89,8 @@ type server struct {
 	gracefulTimeout time.Duration
 	// disableRequestLogger stops logging of request information to the global logger
 	disableRequestLogger bool
+	// ignore404Paths
+	ignore404Paths []string
 	// logger is the custom zerolog logger
 	logger *logger.CustomLogger
 	// middleware is an array of middleware options that will be applied.
@@ -182,7 +184,7 @@ func newServer(options ...Option) (*server, error) {
 
 	// setting up request logging middleware
 	if !s.disableRequestLogger {
-		s.router.Use(middleware.RequestLogger(&log.Logger))
+		s.router.Use(middleware.RequestLogger(&log.Logger, s.ignore404Paths...))
 	}
 
 	// setup oto server


### PR DESCRIPTION
By default all http status codes are logged. For some routes/path it is useful to suppress the logging. This merge-request makes it possible to suppress 404 log-lines when the match the path. 

```toml
{code:toml}
[logging]
# "*" ignores all 404
# paths ending with "*" are wildcards
# all paths should start with a forward slash "*"
# an empty [] will log all request.
exclude404Path = ["*"]
{code}
```