### PR TITLE
Feature/v0.3.1/oai pmh harvesting list fix

### DIFF
--- a/ikuzo/ikuzoctl/cmd/config/harvest.go
+++ b/ikuzo/ikuzoctl/cmd/config/harvest.go
@@ -15,6 +15,7 @@ type Harvest struct {
 	EadHarvestURL  string   `json:"eadHarvestUrl"`
 	MetsHarvestURL string   `json:"metsHarvestUrl"`
 	HarvestPath    string   `json:"harvestPath"`
+	RequireSetSpec bool     `json:"requireSetSpec"`
 	service        *harvest.Service
 }
 

--- a/ikuzo/ikuzoctl/cmd/config/oaipmh.go
+++ b/ikuzo/ikuzoctl/cmd/config/oaipmh.go
@@ -22,7 +22,7 @@ func (o *OAIPMH) NewService(cfg *Config) (*oaipmh.Service, error) {
 
 	svc, err := oaipmh.NewService(
 		oaipmh.SetStore(store),
-		oaipmh.SetRequireSetSpec(false),
+		oaipmh.SetRequireSetSpec(cfg.Harvest.RequireSetSpec),
 	)
 	if err != nil {
 		return nil, err

--- a/ikuzo/service/x/oaipmh/handle_verbs.go
+++ b/ikuzo/service/x/oaipmh/handle_verbs.go
@@ -184,7 +184,7 @@ func (s *Service) handleListIdentifiers(resp *Response) error {
 		return fmt.Errorf("cannot get request config: %w", err)
 	}
 
-	if cfg.DatasetID == "" {
+	if s.requireSetSpecForList && cfg.DatasetID == "" {
 		resp.Error = append(resp.Error, ErrBadArgument)
 		return nil
 	}
@@ -231,7 +231,7 @@ func (s *Service) handleListRecords(resp *Response) error {
 		return fmt.Errorf("cannot get request config: %w", err)
 	}
 
-	if cfg.DatasetID == "" {
+	if s.requireSetSpecForList && cfg.DatasetID == "" {
 		resp.Error = append(resp.Error, ErrBadArgument)
 		return nil
 	}


### PR DESCRIPTION
Before the setspec was required when harvesting 'ListRecords' and 'ListSets'. 

This change makes the default behaviour false. Via the configuration `harvest.requireSetSpec=true` you can revert back to the previous behaviour.
