### PR TITLE
Hub 493 stuksoort postwaarden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ frontend/ead/public
 
 # ignore default configuration
 hub3.toml
+
+# ignore local test files
+coverage.txt

--- a/config/config.go
+++ b/config/config.go
@@ -261,7 +261,7 @@ type EAD struct {
 	GenreFormDefault string   `json:"genreFormDefault"`
 	TreeFields       []string `json:"treeFields"`
 	SearchFields     []string `json:"searchFields"`
-	Genreforms		 []string   `json:"genreforms"`
+	Genreforms		 []string `json:"genreforms"`
 }
 
 func setDefaults() {

--- a/config/config.go
+++ b/config/config.go
@@ -261,6 +261,7 @@ type EAD struct {
 	GenreFormDefault string   `json:"genreFormDefault"`
 	TreeFields       []string `json:"treeFields"`
 	SearchFields     []string `json:"searchFields"`
+	Genreforms		 []string   `json:"genreforms"`
 }
 
 func setDefaults() {

--- a/hub3.toml
+++ b/hub3.toml
@@ -279,7 +279,7 @@ metrics = true
 workers = 1
 processDigital = false
 processDigitalIfMissing = false
-
+genreforms = []
 searchURL = ""
 genreFormDefault = "other/unknown"
 treeFields = [

--- a/hub3.toml
+++ b/hub3.toml
@@ -279,6 +279,7 @@ metrics = true
 workers = 1
 processDigital = false
 processDigitalIfMissing = false
+# if empty everything is allowed
 genreforms = []
 searchURL = ""
 genreFormDefault = "other/unknown"

--- a/hub3/ead/nodes.go
+++ b/hub3/ead/nodes.go
@@ -247,19 +247,30 @@ func CreateTree(cfg *NodeConfig, n *Node, hubID string, id string) *fragments.Tr
 		}
 	}
 
-	if len(config.Config.EAD.Genreforms) == 0 {
-		tree.Genreform = n.Header.Genreform
-		return tree
-	}
-
 	tree.Genreform = func() string {
-		for _, a := range config.Config.EAD.Genreforms {
-			if a == n.Header.Genreform {
-				return a
+		genreForm := n.Header.Genreform
+		if len(config.Config.EAD.Genreforms) > 0 {
+			// reset genreForm value
+			genreForm = ""
+
+			for _, a := range config.Config.EAD.Genreforms {
+				if a == n.Header.Genreform {
+					return a
+				}
+			}
+			if genreForm == "" {
+				log.Warn().
+					Str("genreForm", n.Header.Genreform).
+					Str("defaultValue", config.Config.EAD.GenreFormDefault).
+					Msg("unknown genreForm value, using default")
 			}
 		}
-		log.Error().Msg("Onbekende genreform!")
-		return config.Config.EAD.GenreFormDefault
+
+		if genreForm == "" && config.Config.EAD.GenreFormDefault != "" {
+			return config.Config.EAD.GenreFormDefault
+		}
+
+		return genreForm
 	}()
 
 	return tree

--- a/hub3/ead/nodes.go
+++ b/hub3/ead/nodes.go
@@ -247,24 +247,15 @@ func CreateTree(cfg *NodeConfig, n *Node, hubID string, id string) *fragments.Tr
 		}
 	}
 
-	if len(config.Config.EAD.Genreforms) == 0 {
-		tree.Genreform = n.Header.Genreform
-		return tree
-	}
-
-	if len(config.Config.EAD.Genreforms) > 1 {
-		var b bool
+	tree.Genreform = func() string {
 		for _, a := range config.Config.EAD.Genreforms {
 			if a == n.Header.Genreform {
-				tree.Genreform = n.Header.Genreform
-				b = true
+				return a
 			}
 		}
-		if !b {
-			log.Error().Msg("Onbekende genreform!")
-			tree.Genreform = config.Config.EAD.GenreFormDefault
-		}
-	}
+		log.Error().Msg("Onbekende genreform!")
+		return config.Config.EAD.GenreFormDefault
+	}()
 
 	return tree
 }

--- a/hub3/ead/nodes.go
+++ b/hub3/ead/nodes.go
@@ -247,6 +247,11 @@ func CreateTree(cfg *NodeConfig, n *Node, hubID string, id string) *fragments.Tr
 		}
 	}
 
+	if len(config.Config.EAD.Genreforms) == 0 {
+		tree.Genreform = n.Header.Genreform
+		return tree
+	}
+
 	if len(config.Config.EAD.Genreforms) > 1 {
 		var b bool
 		for _, a := range config.Config.EAD.Genreforms {

--- a/hub3/ead/nodes.go
+++ b/hub3/ead/nodes.go
@@ -200,6 +200,7 @@ func CreateTree(cfg *NodeConfig, n *Node, hubID string, id string) *fragments.Tr
 	tree.Access = n.AccessRestrict
 	tree.HasRestriction = n.AccessRestrict != ""
 	tree.PhysDesc = n.Header.Physdesc
+	tree.Genreform = n.Header.Genreform
 
 	if tree.HasDigitalObject {
 		daoCfg := newDaoConfig(cfg, tree)

--- a/hub3/ead/nodes.go
+++ b/hub3/ead/nodes.go
@@ -247,6 +247,11 @@ func CreateTree(cfg *NodeConfig, n *Node, hubID string, id string) *fragments.Tr
 		}
 	}
 
+	if len(config.Config.EAD.Genreforms) == 0 {
+		tree.Genreform = n.Header.Genreform
+		return tree
+	}
+
 	tree.Genreform = func() string {
 		for _, a := range config.Config.EAD.Genreforms {
 			if a == n.Header.Genreform {

--- a/hub3/ead/nodes.go
+++ b/hub3/ead/nodes.go
@@ -200,7 +200,6 @@ func CreateTree(cfg *NodeConfig, n *Node, hubID string, id string) *fragments.Tr
 	tree.Access = n.AccessRestrict
 	tree.HasRestriction = n.AccessRestrict != ""
 	tree.PhysDesc = n.Header.Physdesc
-	tree.Genreform = n.Header.Genreform
 
 	if tree.HasDigitalObject {
 		daoCfg := newDaoConfig(cfg, tree)
@@ -245,6 +244,21 @@ func CreateTree(cfg *NodeConfig, n *Node, hubID string, id string) *fragments.Tr
 				tree.MimeTypes = daoCfg.MimeTypes
 				tree.DOCount = daoCfg.ObjectCount
 			}
+		}
+	}
+
+
+	if len(config.Config.EAD.Genreforms) > 1 {
+		var b bool
+		for _, a := range config.Config.EAD.Genreforms {
+			if a == n.Header.Genreform {
+				tree.Genreform = n.Header.Genreform
+				b = true
+			}
+		}
+		if !b {
+			log.Error().Msg("Onbekende genreform!")
+			tree.Genreform = config.Config.EAD.GenreFormDefault
 		}
 	}
 

--- a/hub3/ead/nodes.go
+++ b/hub3/ead/nodes.go
@@ -247,7 +247,6 @@ func CreateTree(cfg *NodeConfig, n *Node, hubID string, id string) *fragments.Tr
 		}
 	}
 
-
 	if len(config.Config.EAD.Genreforms) > 1 {
 		var b bool
 		for _, a := range config.Config.EAD.Genreforms {

--- a/hub3/fragments/resource.go
+++ b/hub3/fragments/resource.go
@@ -112,6 +112,7 @@ type Tree struct {
 	Material         string              `json:"material,omitempty"`
 	PhysDesc         string              `json:"physDesc,omitempty"`
 	Fields           map[string][]string `json:"fields,omitempty"`
+	Genreform        string              `json:"genreform,omitempty"`
 }
 
 // DeepCopy creates a deep-copy of a Tree.

--- a/ikuzo/driver/elasticsearch/internal/mapping/update.go
+++ b/ikuzo/driver/elasticsearch/internal/mapping/update.go
@@ -25,7 +25,7 @@ import (
 // this should prevent changes to the mapping that are not reflected in the update.
 // this is needed for all mappings that have strict fields.
 const (
-	v2MappingSha       = "fb1d72134758dea3"
+	v2MappingSha       = "a32f7799756ceada"
 	v2UpdateMappingSha = "b8d4f29ec1e660df"
 	fragmentMappingSha = "7607ca7737d17e4a"
 )

--- a/ikuzo/driver/elasticsearch/internal/mapping/update.go
+++ b/ikuzo/driver/elasticsearch/internal/mapping/update.go
@@ -26,7 +26,7 @@ import (
 // this is needed for all mappings that have strict fields.
 const (
 	v2MappingSha       = "a32f7799756ceada"
-	v2UpdateMappingSha = "b8d4f29ec1e660df"
+	v2UpdateMappingSha = "9baa427287dd6be0"
 	fragmentMappingSha = "7607ca7737d17e4a"
 )
 

--- a/ikuzo/driver/elasticsearch/internal/mapping/v2.go
+++ b/ikuzo/driver/elasticsearch/internal/mapping/v2.go
@@ -125,7 +125,8 @@ var v2Mapping = `{
 						"mimeType": {"type": "keyword"},
 						"periods": {"type": "keyword"},
 						"hasDigitalObject": {"type": "boolean"},
-						"hasRestriction": {"type": "boolean"}
+						"hasRestriction": {"type": "boolean"},
+						"genreform": {"type": "keyword"},
 					}
 				},
 				"recordType": {"type": "short"},

--- a/ikuzo/driver/elasticsearch/internal/mapping/v2.go
+++ b/ikuzo/driver/elasticsearch/internal/mapping/v2.go
@@ -126,7 +126,7 @@ var v2Mapping = `{
 						"periods": {"type": "keyword"},
 						"hasDigitalObject": {"type": "boolean"},
 						"hasRestriction": {"type": "boolean"},
-						"genreform": {"type": "keyword"},
+						"genreform": {"type": "keyword"}
 					}
 				},
 				"recordType": {"type": "short"},

--- a/ikuzo/driver/elasticsearch/internal/mapping/v2.go
+++ b/ikuzo/driver/elasticsearch/internal/mapping/v2.go
@@ -210,7 +210,8 @@ var v2MappingUpdate = `{
       "properties": {
         "physDesc": {"type": "keyword"},
         "periodDesc": { "type": "keyword"},
-		"rawContent": {"type": "text", "store": false}
+		"rawContent": {"type": "text", "store": false},
+		"genreform": {"type": "keyword"}
       }
     },
 	"protobuf": {


### PR DESCRIPTION
Genreform for ingested EADs should be able to be configured as controlled values. The controlled values come from the configuration files and are added to the Tree object for indexing and querying.