### PR TITLE
Retrieve info from existing mets file if process digital is disabled

### DIFF
--- a/hub3/ead/nodes.go
+++ b/hub3/ead/nodes.go
@@ -15,7 +15,6 @@
 package ead
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -215,16 +214,12 @@ func CreateTree(cfg *NodeConfig, n *Node, hubID string, id string) *fragments.Tr
 		// If cfg.ProcessDigital is disabled we're attempting to update daoCfg with
 		// data from an existing mets file otherwise it will be overwritten with
 		// sensible defaults.
-		if _, err := os.Stat(daoCfg.GetMetsFilePath()); err == nil && !cfg.ProcessDigital {
-			data, err := os.ReadFile(daoCfg.GetMetsFilePath() + ".json")
-			if err == nil {
-				var cfg DaoConfig
-				if err := json.Unmarshal(data, &cfg); err == nil {
-					daoCfg.MimeTypes = cfg.MimeTypes
-					daoCfg.ObjectCount = cfg.ObjectCount
-					daoCfg.FileUUIDs = cfg.FileUUIDs
-					daoCfg.Filenames = cfg.Filenames
-				}
+		if !cfg.ProcessDigital && daoCfg.daoConfigExists() {
+			if cfg, err := GetDaoConfig(daoCfg.ArchiveID, daoCfg.UUID); err == nil {
+				daoCfg.MimeTypes = cfg.MimeTypes
+				daoCfg.ObjectCount = cfg.ObjectCount
+				daoCfg.FileUUIDs = cfg.FileUUIDs
+				daoCfg.Filenames = cfg.Filenames
 			}
 		}
 


### PR DESCRIPTION
Currently the mime types are lost when reindexing an EAD with `mets = false` after indexing it with `mets = true`. This change should fix it by reading an existing mets file.