### PR TITLE
LOD resolver configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -244,6 +244,7 @@ type LOD struct {
 	RDF               string `json:"rdf"`            // the endpoint that renders the RDF data in the requested RDF format. Currently, JSON-LD and N-triples are supported
 	SingleEndpoint    string `json:"singleEndpoint"` // when this is set it overrides the other endpoints
 	HTMLRedirectRegex string `json:"redirectregex"`  // the regular expression to convert the subject uri to the uri for the external Page view
+	Store             string // default sparql otherwise fragments
 }
 
 // SiteMap holds all the configuration for the sitemap generation

--- a/ikuzo/service/x/bulk/parser.go
+++ b/ikuzo/service/x/bulk/parser.go
@@ -21,11 +21,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/rs/zerolog"
 	"io"
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/rs/zerolog"
 
 	"github.com/delving/hub3/config"
 	"github.com/delving/hub3/hub3/fragments"
@@ -178,7 +179,6 @@ func (p *Parser) dropOrphans(req *Request) error {
 }
 
 func addLogger(datasetID string) zerolog.Logger {
-
 	switch {
 	case strings.HasSuffix(datasetID, "ntfoto"):
 		return log.With().Str("svc", "ntfoto").Logger()
@@ -293,6 +293,12 @@ func (p *Parser) Publish(ctx context.Context, req *Request) error {
 	}
 
 	_ = fb.Doc()
+
+	for _, tag := range fb.FragmentGraph().Meta.Tags {
+		if tag == "fragmentsOnly" {
+			p.indexTypes = []string{"fragments"}
+		}
+	}
 
 	for _, indexType := range p.indexTypes {
 		switch indexType {

--- a/ikuzo/service/x/bulk/request.go
+++ b/ikuzo/service/x/bulk/request.go
@@ -79,6 +79,13 @@ func (req *Request) createFragmentBuilder(revision int) (*fragments.FragmentBuil
 		}
 	}
 
+	if req.RecordType != "" {
+		tags := strings.Split(req.RecordType, ",")
+		for _, tag := range tags {
+			fg.Meta.Tags = append(fg.Meta.Tags, strings.TrimSpace(tag))
+		}
+	}
+
 	if tags, ok := config.Config.DatasetTagMap.Get(req.DatasetID); ok {
 		fg.Meta.Tags = append(fg.Meta.Tags, tags...)
 	}


### PR DESCRIPTION
LOD resolver now defaults to sparql but has support for LDF based LOD resolving. When `lod.store=fragments` in the TOML configuration the LDF based resolver is used. 