### PR TITLE
added tagFilters configuration for oaipmh service

### DIFF
--- a/hub3.toml
+++ b/hub3.toml
@@ -182,6 +182,7 @@ harvestDelay = 1
 eadHarvestUrl = "http://localhost:3000/oai/ead"
 metsHarvestUrl = "http://localhost:3000/oai/mets"
 harvestPath = "/tmp/oaipmh"
+tagFilters = ["narthex"]
 
 [oaipmh]
 # options: no, transient, persistent

--- a/ikuzo/driver/elasticsearch/oaipmh_store.go
+++ b/ikuzo/driver/elasticsearch/oaipmh_store.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 
 	"github.com/delving/hub3/hub3/fragments"
 	"github.com/delving/hub3/ikuzo/rdf"
@@ -32,8 +31,9 @@ func (c *Client) NewOAIPMHStore() (*OAIPMHStore, error) {
 
 func (o *OAIPMHStore) ListSets(ctx context.Context, q *oaipmh.RequestConfig) (res oaipmh.Resumable, err error) {
 	query := elastic.NewBoolQuery().
-		Must(elastic.NewTermQuery("meta.orgID", q.OrgID)).
-		Must(elastic.NewTermQuery("meta.tags", "narthex"))
+		Must(elastic.NewTermQuery("meta.orgID", q.OrgID))
+
+	query = addFilters(q, query)
 
 	specCountAgg := elastic.NewCardinalityAggregation().
 		Field("meta.spec")
@@ -99,10 +99,23 @@ type resumableResponse struct {
 	pitPayload string // payload for point in time parsing
 }
 
+func addFilters(q *oaipmh.RequestConfig, query *elasticsearch.Query) *elasticsearch.Query {
+	if len(q.Filters) > 0 {
+		fq := elastic.NewBoolQuery()
+		for _, filt := range q.Filters {
+			fq = fq.Should(elastic.NewTermQuery("meta.tags", filt))
+		}
+		query = query.Must(fq)
+	}
+
+	return query
+}
+
 func (o *OAIPMHStore) getRecords(ctx context.Context, q *oaipmh.RequestConfig, headersOnly bool) (resp resumableResponse, err error) {
 	query := elastic.NewBoolQuery().
-		Must(elastic.NewTermQuery("meta.orgID", q.OrgID)).
-		Must(elastic.NewTermQuery("meta.tags", "narthex"))
+		Must(elastic.NewTermQuery("meta.orgID", q.OrgID))
+
+	query = addFilters(q, query)
 
 	if q.DatasetID != "" {
 		query = query.Must(elastic.NewTermQuery("meta.spec", q.DatasetID))
@@ -135,7 +148,6 @@ func (o *OAIPMHStore) getRecords(ctx context.Context, q *oaipmh.RequestConfig, h
 	}
 
 	search := o.c.search.Search().
-		// Index(IndexNames{}.GetIndexName(q.OrgID)).
 		PointInTime(elastic.NewPointInTimeWithKeepAlive(q.StoreCursor, "1m")).
 		Sort("_shard_doc", true).
 		Size(o.ResponseSize).
@@ -208,8 +220,6 @@ func (o *OAIPMHStore) ListIdentifiers(ctx context.Context, q *oaipmh.RequestConf
 
 func (o *OAIPMHStore) ListRecords(ctx context.Context, q *oaipmh.RequestConfig) (res oaipmh.Resumable, err error) {
 	resp, err := o.getRecords(ctx, q, false)
-
-	log.Printf("metadataPrefix: %#v", q.FirstRequest)
 
 	for _, raw := range resp.records {
 		rec, getErr := o.getOAIPMHRecord(raw, q.FirstRequest.MetadataPrefix, true)

--- a/ikuzo/ikuzoctl/cmd/config/harvest.go
+++ b/ikuzo/ikuzoctl/cmd/config/harvest.go
@@ -16,6 +16,7 @@ type Harvest struct {
 	MetsHarvestURL string   `json:"metsHarvestUrl"`
 	HarvestPath    string   `json:"harvestPath"`
 	RequireSetSpec bool     `json:"requireSetSpec"`
+	TagFilters     []string `json:"tagFilters"`
 	service        *harvest.Service
 }
 

--- a/ikuzo/ikuzoctl/cmd/config/oaipmh.go
+++ b/ikuzo/ikuzoctl/cmd/config/oaipmh.go
@@ -23,6 +23,7 @@ func (o *OAIPMH) NewService(cfg *Config) (*oaipmh.Service, error) {
 	svc, err := oaipmh.NewService(
 		oaipmh.SetStore(store),
 		oaipmh.SetRequireSetSpec(cfg.Harvest.RequireSetSpec),
+		oaipmh.SetTagFilters(cfg.Harvest.TagFilters),
 	)
 	if err != nil {
 		return nil, err

--- a/ikuzo/service/x/oaipmh/options.go
+++ b/ikuzo/service/x/oaipmh/options.go
@@ -17,3 +17,12 @@ func SetRequireSetSpec(allow bool) Option {
 		return nil
 	}
 }
+
+// SetTagFilters add filters to limit which records and sets are
+// available for OAI-PMH harvesting
+func SetTagFilters(filters []string) Option {
+	return func(s *Service) error {
+		s.filters = filters
+		return nil
+	}
+}

--- a/ikuzo/service/x/oaipmh/service.go
+++ b/ikuzo/service/x/oaipmh/service.go
@@ -22,12 +22,14 @@ type Service struct {
 	m                     sync.RWMutex
 	sid                   *shortid.Shortid
 	requireSetSpecForList bool
+	filters               []string
 }
 
 func NewService(options ...Option) (*Service, error) {
 	s := &Service{
 		steps:                 make(map[string]RequestConfig),
 		requireSetSpecForList: true,
+		filters:               []string{"narthex"},
 	}
 
 	sid, err := shortid.New(1, shortid.DefaultABC, 2342)

--- a/ikuzo/service/x/oaipmh/store.go
+++ b/ikuzo/service/x/oaipmh/store.go
@@ -22,6 +22,7 @@ type RequestConfig struct {
 	DatasetID      string
 	TotalSize      int
 	Finished       bool
+	Filters        []string
 }
 
 func (q *RequestConfig) IsResumedRequest() bool {


### PR DESCRIPTION
With these tagFilters you are able to exclude certain datasets from the oaipmh service. 

These tags can be  set via Narthex in the tags field or in the configuration via the rdftag functionality.