### PR TITLE
Stream results from elasticsearch with a callback

### DIFF
--- a/ikuzo/driver/elasticsearch/stream.go
+++ b/ikuzo/driver/elasticsearch/stream.go
@@ -1,0 +1,126 @@
+package elasticsearch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/delving/hub3/hub3/fragments"
+	"github.com/olivere/elastic/v7"
+)
+
+var ErrEndOfScroll = errors.New("reached end of scroll")
+
+type StreamConfig struct {
+	Query      elastic.Query
+	IndexNames []string
+	Fsc        *elastic.FetchSourceContext
+	pitID      string
+}
+
+// Stream can be used to stream process results of a query from ElasticSearch
+func (c *Client) Stream(
+	ctx context.Context, cfg *StreamConfig,
+	fn func(hit *elastic.SearchHit) error,
+) (seen int, err error) {
+	// Create a Point In Time
+	openResp, err := c.search.OpenPointInTime(cfg.IndexNames...).
+		KeepAlive("1m").
+		Pretty(true).
+		Do(context.Background())
+	if err != nil {
+		return 0, err
+	}
+
+	defer func() {
+		_, err := c.search.ClosePointInTime(openResp.Id).Pretty(true).Do(context.Background())
+		if err != nil {
+			c.log.Error().Err(err).Msg("unable to close point in time")
+		}
+	}()
+
+	cfg.pitID = openResp.Id
+
+	var (
+		esPage      int
+		totalSeen   int
+		searchAfter []interface{}
+		hits        []*elastic.SearchHit
+	)
+
+	for {
+		hits, searchAfter, err = c.next(cfg, searchAfter)
+		if err != nil {
+			break
+		}
+
+		for _, hit := range hits {
+			if fnErr := fn(hit); fnErr != nil {
+				return 0, fnErr
+			}
+		}
+		esPage++
+	}
+
+	if err != nil {
+		if !errors.Is(err, ErrEndOfScroll) {
+			return 0, err
+		}
+
+		if totalSeen == 0 {
+			return totalSeen, fmt.Errorf("no hits for query %#v, with error: %v", cfg.Query, err)
+		}
+	}
+
+	return totalSeen, nil
+}
+
+func (c *Client) next(cfg *StreamConfig, searchAfter []interface{}) ([]*elastic.SearchHit, []interface{}, error) {
+	pageSize := 1000
+
+	search := c.search.Search().
+		Size(pageSize).
+		Query(cfg.Query).
+		PointInTime(elastic.NewPointInTimeWithKeepAlive(cfg.pitID, "1m")).
+		Sort("meta.hubID", true)
+
+	if cfg.Fsc != nil {
+		search = search.FetchSourceContext(cfg.Fsc)
+	}
+
+	if len(searchAfter) > 0 {
+		search = search.SearchAfter(searchAfter...)
+	}
+
+	resp, err := search.Do(context.Background())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if resp.Error != nil {
+		return nil, nil, fmt.Errorf("%s", resp.Error.Reason)
+	}
+
+	if len(resp.Hits.Hits) == 0 {
+		return nil, nil, ErrEndOfScroll
+	}
+
+	var newSearchAfter []interface{}
+	newSearchAfter = resp.Hits.Hits[len(resp.Hits.Hits)-1].Sort
+	// for _, hit := range resp.Hits.Hits {
+	// newSearchAfter = hit.Sort
+
+	// r, err := decodeFragmentGraph(hit.Source)
+	// if err != nil {
+	// return nil, nil, err
+	// }
+
+	// headers = append(headers, r.Meta)
+	// }
+
+	return resp.Hits.Hits, newSearchAfter, nil
+}
+
+func publishFragments(fg *fragments.FragmentGraph) error {
+	return nil
+}

--- a/ikuzo/driver/elasticsearch/stream.go
+++ b/ikuzo/driver/elasticsearch/stream.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/delving/hub3/hub3/fragments"
 	"github.com/olivere/elastic/v7"
 )
 
@@ -107,20 +106,6 @@ func (c *Client) next(cfg *StreamConfig, searchAfter []interface{}) ([]*elastic.
 
 	var newSearchAfter []interface{}
 	newSearchAfter = resp.Hits.Hits[len(resp.Hits.Hits)-1].Sort
-	// for _, hit := range resp.Hits.Hits {
-	// newSearchAfter = hit.Sort
-
-	// r, err := decodeFragmentGraph(hit.Source)
-	// if err != nil {
-	// return nil, nil, err
-	// }
-
-	// headers = append(headers, r.Meta)
-	// }
 
 	return resp.Hits.Hits, newSearchAfter, nil
-}
-
-func publishFragments(fg *fragments.FragmentGraph) error {
-	return nil
 }

--- a/ikuzo/driver/elasticsearch/stream_test.go
+++ b/ikuzo/driver/elasticsearch/stream_test.go
@@ -1,0 +1,49 @@
+package elasticsearch
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"github.com/matryer/is"
+	"github.com/olivere/elastic/v7"
+)
+
+func TestStreamFragments(t *testing.T) {
+	is := is.New(t)
+
+	testSets := []string{
+		"mauritshuis",
+		// "museum-de-fundatie",
+		// "rijksmuseum",
+		// "catharijneconvent",
+		// "stedelijk-museum-schiedam",
+		// "van-abbe-museum",
+		// "museum-belvedere",
+		// "rijksakademie",
+		// "moderne-kunst-museum-deventer",
+	}
+
+	query := elastic.NewBoolQuery()
+	for _, setSpec := range testSets {
+		query.Should(elastic.NewTermQuery("meta.spec", setSpec))
+	}
+
+	cfg := Config{Urls: []string{"http://localhost:9200"}}
+	client, err := NewClient(&cfg)
+	is.NoErr(err)
+
+	streamConfig := &StreamConfig{
+		Query:      query,
+		IndexNames: []string{"dcnv2_20200526062245.616"},
+	}
+
+	printFunc := func(hit *elastic.SearchHit) error {
+		log.Printf("hit: %s", hit.Id)
+		return nil
+	}
+
+	seen, streamErr := client.Stream(context.Background(), streamConfig, printFunc)
+	is.NoErr(streamErr)
+	is.Equal(seen, 856)
+}


### PR DESCRIPTION
This generic functionality allows us to stream results from elasticsearch and process the result with a callback.

This can be used to migrate indices or make a backup.