### PR TITLE
fix: remove duplicate urns from edm:WebResource

### DIFF
--- a/hub3/fragments/v1.go
+++ b/hub3/fragments/v1.go
@@ -264,6 +264,8 @@ func (fb *FragmentBuilder) GetUrns() []string {
 		s := strings.Trim(t.Subject.String(), "<>")
 		if strings.HasPrefix(s, "urn:") {
 			urns = append(urns, s)
+			// remove urn this will be added by the ResolveRemoteWebResources call
+			fb.Graph.Remove(t)
 		}
 	}
 


### PR DESCRIPTION
When the request urn is not exactly the same as the urn returned from the mediamanager then in some cases both subject urn: remained in the RDF Graph. This fix resolves that.