### PR TITLE
feature: allow for custom url-prefixes in the nde register urls.

### DIFF
--- a/hub3.toml
+++ b/hub3.toml
@@ -575,26 +575,28 @@ base = "http://www.w3.org/ns/odrl/2/"
 enabled = true
 dataPath = "/tmp/trs"
 
-[NDE.default]
+[NDE.toegang]
 enabled = true
+default = true
 name = "Linked Data van het NA"
 description = "Alle linked data zoals beschikbaar gesteld door het Nationaal Archief."
 defaultLanguages = ["nl"]
 defaultLicense = "http://creativecommons.org/publicdomain/zero/1.0/"
 datasetFmt = "%s/onderzoeken/archief/%s/"
 recordTypeFilter = "ead"
+urlPrefix = "toegang"
 
-[NDE.default.publisher]
+[NDE.toegang.publisher]
 name = "Nationaal Archief"
 altName = "NA"
 url = "https://www.nationaalarchief.nl"
 
-[[NDE.default.distribution]]
+[[NDE.toegang.distribution]]
 datasetType = "ead"
 mimeType = "application/pdf"
 downloadFmt = "%s/onderzoeken/archief/%s/download/pdf"
 
-[[NDE.default.distribution]]
+[[NDE.toegang.distribution]]
 datasetType = "ead"
 mimeType = "application/xml"
 downloadFmt = "%s/onderzoeken/archief/%s/download/xml"
@@ -607,6 +609,7 @@ defaultLanguages = ["nl"]
 defaultLicense = "http://creativecommons.org/publicdomain/zero/1.0/"
 datasetFmt = "%s/onderzoeken/index/%s?activeTab=nt"
 RecordTypeFilter = "nt"
+urlPrefix = "index"
 
 [NDE.nt.publisher]
 name = "Nationaal Archief"
@@ -626,6 +629,7 @@ defaultLanguages = ["nl"]
 defaultLicense = "http://creativecommons.org/publicdomain/zero/1.0/"
 datasetFmt = "%s/onderzoeken/index/%s?activeTab=photo"
 RecordTypeFilter = "photo"
+urlPrefix = "foto"
 
 [NDE.photo.publisher]
 name = "Nationaal Archief"

--- a/ikuzo/ikuzoctl/cmd/config/nde.go
+++ b/ikuzo/ikuzoctl/cmd/config/nde.go
@@ -11,6 +11,7 @@ import (
 type NDE struct{}
 
 type NDECfg struct {
+	Default          bool
 	URLPrefix        string   `json:"urlPrefix"`
 	Enabled          bool     `json:"enabled"`
 	Description      string   `json:"description"`
@@ -35,8 +36,13 @@ func (n *NDE) createConfig(cfg *Config) ([]*nde.RegisterConfig, error) {
 			return nil, fmt.Errorf("NDE config must be set for register")
 		}
 
+		if ndeCfg.URLPrefix == "" {
+			ndeCfg.URLPrefix = name
+		}
+
 		config := &nde.RegisterConfig{
-			URLPrefix:        name,
+			Default:          ndeCfg.Default,
+			URLPrefix:        ndeCfg.URLPrefix,
 			DataPath:         cfg.EAD.CacheDir,
 			DatasetFmt:       ndeCfg.DatasetFmt,
 			RDFBaseURL:       cfg.RDF.BaseURL,

--- a/ikuzo/service/x/nde/dataset.go
+++ b/ikuzo/service/x/nde/dataset.go
@@ -68,7 +68,7 @@ func (s *Service) createDataSet(ds *models.DataSet) (*Dataset, error) {
 		ds.RecordType = "narthex"
 	}
 
-	r, ok := s.lookUp[ds.RecordType]
+	r, ok := s.recordTypeLookup[ds.RecordType]
 	if !ok {
 		r = s.defaultCfg
 	}
@@ -133,7 +133,7 @@ func (s *Service) getDatasets(orgID string, tag string) ([]*models.DataSet, erro
 
 	var sets []*models.DataSet
 	if err := query.Find(&sets); err != nil {
-		return sets, err
+		return sets, fmt.Errorf("no sets match query %s %s; %w", orgID, tag, err)
 	}
 
 	return sets, nil

--- a/ikuzo/service/x/nde/register.go
+++ b/ikuzo/service/x/nde/register.go
@@ -12,6 +12,7 @@ type DistributionCfg struct {
 }
 
 type RegisterConfig struct {
+	Default          bool
 	URLPrefix        string `json:"urlPrefix"`
 	RDFBaseURL       string
 	Description      string

--- a/ikuzo/service/x/nde/routes.go
+++ b/ikuzo/service/x/nde/routes.go
@@ -12,15 +12,16 @@ import (
 func (s *Service) Routes(router chi.Router) {
 	router.Get("/id/datacatalog/*", s.lodRedirect)
 	router.Get("/id/dataset/*", s.lodRedirect)
-	router.Get("/doc/datacatalog", defaultRedirect)
-	router.Get("/doc/dataset/{spec}", defaultRedirect)
+	router.Get("/id/datacatalog/", s.lodRedirect)
+	router.Get("/doc/datacatalog", s.defaultRedirect)
+	router.Get("/doc/dataset/{spec}", s.defaultRedirect)
 	router.Get("/doc/datacatalog/{cfgName}", s.HandleCatalog)
 	router.Get("/doc/dataset/{cfgName}/{spec}", s.HandleDataset)
 }
 
 func (s *Service) lodRedirect(w http.ResponseWriter, r *http.Request) {
 	if !strings.HasPrefix(r.URL.Path, "/id/") {
-		http.Error(w, "unknow lod prefix", http.StatusBadRequest)
+		http.Error(w, "unknown lod prefix", http.StatusBadRequest)
 		return
 	}
 
@@ -28,10 +29,10 @@ func (s *Service) lodRedirect(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, newPath, http.StatusFound)
 }
 
-func defaultRedirect(w http.ResponseWriter, r *http.Request) {
+func (s *Service) defaultRedirect(w http.ResponseWriter, r *http.Request) {
 	spec := chi.URLParam(r, "spec")
 	if spec == "" {
-		newPath := fmt.Sprintf("%s/default", r.URL.Path)
+		newPath := fmt.Sprintf("%s/%s", r.URL.Path, s.defaultCfg.URLPrefix)
 		http.Redirect(w, r, newPath, http.StatusFound)
 
 		return
@@ -41,7 +42,7 @@ func defaultRedirect(w http.ResponseWriter, r *http.Request) {
 	newpath := []string{
 		parts[0],
 		parts[1],
-		"default",
+		s.defaultCfg.URLPrefix,
 		parts[2],
 	}
 


### PR DESCRIPTION
This decouples the internal DataSet.RecordType from the urlPrefix in the routing.