### PR TITLE
feat(nde): add support for hydra based pagination

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,7 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
+    - unused
     - depguard
     - dogsled
     - dupl
@@ -70,24 +70,21 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
     - misspell
     - nakedret
-    - scopelint
+    - exportloopref
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
     - wsl
 
@@ -117,6 +114,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.22.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.52.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/ikuzo/service/x/nde/dataset.go
+++ b/ikuzo/service/x/nde/dataset.go
@@ -85,7 +85,7 @@ func (c *Catalog) addHydraView(currentPage string, totalSize int) error {
 	return nil
 }
 
-const hydraObjectPerPage = 500
+const hydraObjectPerPage = 1000
 
 type HydraView struct {
 	ID          string            `json:"@id,omitempty"`

--- a/ikuzo/service/x/nde/dataset.go
+++ b/ikuzo/service/x/nde/dataset.go
@@ -3,8 +3,11 @@ package nde
 import (
 	"errors"
 	"fmt"
+	"strconv"
 
+	"github.com/asdine/storm"
 	"github.com/asdine/storm/q"
+
 	"github.com/delving/hub3/hub3/ead"
 	"github.com/delving/hub3/hub3/models"
 )
@@ -52,13 +55,74 @@ type Dataset struct {
 }
 
 type Catalog struct {
-	Context     string     `json:"@context,omitempty"`
+	Context     []any      `json:"@context,omitempty"`
 	ID          string     `json:"@id,omitempty"`
-	Type        string     `json:"@type,omitempty"`
+	Type        []string   `json:"@type,omitempty"`
+	HydraView   *HydraView `json:"hydra:view,omitempty"`
 	Name        string     `json:"name,omitempty"`
 	Description string     `json:"description,omitempty"`
 	Publisher   Agent      `json:"publisher,omitempty"`
 	Dataset     []*Dataset `json:"dataset,omitempty"`
+}
+
+func (c *Catalog) addHydraView(currentPage string, totalSize int) error {
+	if currentPage == "" {
+		currentPage = "1"
+	}
+
+	page, err := strconv.Atoi(currentPage)
+	if err != nil {
+		return fmt.Errorf("unable to convert %q to integer", currentPage)
+	}
+	c.HydraView = &HydraView{
+		baseID:      c.ID,
+		Type:        "hydra:PartialCollectionView",
+		TotalItems:  totalSize,
+		currentPage: page,
+	}
+
+	c.HydraView.setPager()
+	return nil
+}
+
+const hydraObjectPerPage = 500
+
+type HydraView struct {
+	ID          string            `json:"@id,omitempty"`
+	Type        string            `json:"@type,omitempty"`
+	First       map[string]string `json:"hydra:first,omitempty"`
+	Next        map[string]string `json:"hydra:next,omitempty"`
+	Last        map[string]string `json:"hydra:last,omitempty"`
+	TotalItems  int               `json:"hydra:totalItems,omitempty"`
+	baseID      string
+	currentPage int
+}
+
+func (hv *HydraView) getBounds() (lower int, upper int) {
+	lower = (hv.currentPage - 1) * hydraObjectPerPage
+	upper = (hv.currentPage * hydraObjectPerPage) - 1
+	return lower, upper
+}
+
+func (hv *HydraView) hydraPage(page int) string {
+	return fmt.Sprintf("%s?page=%d", hv.baseID, page)
+}
+
+func (hv *HydraView) setPager() {
+	if hv.currentPage == 0 {
+		hv.currentPage = 1
+	}
+	hv.ID = hv.hydraPage(hv.currentPage)
+
+	hv.First = map[string]string{"@id": hv.hydraPage(1)}
+	next := hv.currentPage + 1
+	totalPages := int(hv.TotalItems / hydraObjectPerPage)
+	if next < totalPages {
+		hv.Next = map[string]string{"@id": hv.hydraPage(next)}
+	}
+	if totalPages > 1 {
+		hv.Last = map[string]string{"@id": hv.hydraPage(totalPages)}
+	}
 }
 
 func (s *Service) createDataSet(ds *models.DataSet) (*Dataset, error) {
@@ -82,9 +146,12 @@ func (s *Service) createDataSet(ds *models.DataSet) (*Dataset, error) {
 		IncludedInDataCatalog: fmt.Sprintf("%s/id/datacatalog/%s", r.RDFBaseURL, r.URLPrefix),
 		Keywords:              []string{},
 		License:               r.DefaultLicense,
-		MainEntityOfPage:      fmt.Sprintf(r.DatasetFmt, r.publisherURL(), spec),
 		Name:                  spec,
 		Publisher:             r.GetAgent(),
+	}
+
+	if r.DatasetFmt != "" {
+		d.MainEntityOfPage = fmt.Sprintf(r.DatasetFmt, r.publisherURL(), spec)
 	}
 
 	layoutISO := "2006-01-02"
@@ -125,14 +192,20 @@ func (s *Service) getDataset(orgID, spec string) (*Dataset, error) {
 	return d, nil
 }
 
-func (s *Service) getDatasets(orgID string, tag string) ([]*models.DataSet, error) {
-	query := models.ORM().Select(q.And(
+func (s *Service) getDatasetsCount(orgID string, tag string) (int, error) {
+	return s.datasetQuery(orgID, tag).Count(&models.DataSet{})
+}
+
+func (s *Service) datasetQuery(orgID string, tag string) storm.Query {
+	return models.ORM().Select(q.And(
 		q.Eq("OrgID", orgID),
 		q.Eq("RecordType", tag),
 	))
+}
 
+func (s *Service) getDatasets(orgID string, tag string) ([]*models.DataSet, error) {
 	var sets []*models.DataSet
-	if err := query.Find(&sets); err != nil {
+	if err := s.datasetQuery(orgID, tag).Find(&sets); err != nil {
 		return sets, fmt.Errorf("no sets match query %s %s; %w", orgID, tag, err)
 	}
 
@@ -145,13 +218,16 @@ func (s *Service) AddDatasets(orgID string, catalog *Catalog, tag string) error 
 		return fmt.Errorf("unable to get datasets from store: %w", err)
 	}
 
-	for _, ds := range datasets {
-		dataset, err := s.createDataSet(ds)
-		if err != nil {
-			return err
-		}
+	lower, upper := catalog.HydraView.getBounds()
 
-		catalog.Dataset = append(catalog.Dataset, dataset)
+	for idx, ds := range datasets {
+		if idx >= lower && (idx <= upper || upper == 0) {
+			dataset, err := s.createDataSet(ds)
+			if err != nil {
+				return err
+			}
+			catalog.Dataset = append(catalog.Dataset, dataset)
+		}
 	}
 
 	return nil

--- a/ikuzo/service/x/nde/dataset_test.go
+++ b/ikuzo/service/x/nde/dataset_test.go
@@ -1,0 +1,93 @@
+package nde
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestHydraView_setPager(t *testing.T) {
+	type fields struct {
+		Type        string
+		baseID      string
+		total       int
+		currentPage int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *HydraView
+	}{
+		{
+			"no page",
+			fields{
+				Type:        "hydra:PartialCollectionView",
+				baseID:      "/catalog",
+				total:       100,
+				currentPage: 0,
+			},
+			&HydraView{
+				ID:          "/catalog?page=1",
+				Type:        "hydra:PartialCollectionView",
+				First:       map[string]string{"@id": "/catalog?page=1"},
+				baseID:      "/catalog",
+				TotalItems:  100,
+				currentPage: 1,
+			},
+		},
+		{
+			"no page; more pages returned",
+			fields{
+				Type:        "hydra:PartialCollectionView",
+				baseID:      "/catalog",
+				total:       7012,
+				currentPage: 0,
+			},
+			&HydraView{
+				ID:          "/catalog?page=1",
+				Type:        "hydra:PartialCollectionView",
+				First:       map[string]string{"@id": "/catalog?page=1"},
+				Next:        map[string]string{"@id": "/catalog?page=2"},
+				Last:        map[string]string{"@id": "/catalog?page=7"},
+				baseID:      "/catalog",
+				TotalItems:  7012,
+				currentPage: 1,
+			},
+		},
+		{
+			"with page; more pages returned",
+			fields{
+				Type:        "hydra:PartialCollectionView",
+				baseID:      "/catalog",
+				total:       7012,
+				currentPage: 4,
+			},
+			&HydraView{
+				ID:          "/catalog?page=4",
+				Type:        "hydra:PartialCollectionView",
+				First:       map[string]string{"@id": "/catalog?page=1"},
+				Next:        map[string]string{"@id": "/catalog?page=5"},
+				Last:        map[string]string{"@id": "/catalog?page=7"},
+				baseID:      "/catalog",
+				TotalItems:  7012,
+				currentPage: 4,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			hv := &HydraView{
+				Type:        tt.fields.Type,
+				baseID:      tt.fields.baseID,
+				TotalItems:  tt.fields.total,
+				currentPage: tt.fields.currentPage,
+			}
+			hv.setPager()
+
+			if diff := cmp.Diff(tt.want, hv, cmp.AllowUnexported(HydraView{})); diff != "" {
+				t.Errorf("HydraView.setPager() %s; mismatch (-want +got):\n%s", tt.name, diff)
+			}
+		})
+	}
+}

--- a/ikuzo/service/x/nde/dataset_test.go
+++ b/ikuzo/service/x/nde/dataset_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestHydraView_setPager(t *testing.T) {
+	const baseID = "/catalog"
+	const hydraType = "hydra:PartialCollectionView"
+	firstPage := map[string]string{"@id": "/catalog?page=1"}
+
 	type fields struct {
 		Type        string
 		baseID      string
@@ -21,16 +25,16 @@ func TestHydraView_setPager(t *testing.T) {
 		{
 			"no page",
 			fields{
-				Type:        "hydra:PartialCollectionView",
-				baseID:      "/catalog",
+				Type:        hydraType,
+				baseID:      baseID,
 				total:       100,
 				currentPage: 0,
 			},
 			&HydraView{
 				ID:          "/catalog?page=1",
-				Type:        "hydra:PartialCollectionView",
-				First:       map[string]string{"@id": "/catalog?page=1"},
-				baseID:      "/catalog",
+				Type:        hydraType,
+				baseID:      baseID,
+				First:       firstPage,
 				TotalItems:  100,
 				currentPage: 1,
 			},
@@ -39,17 +43,17 @@ func TestHydraView_setPager(t *testing.T) {
 			"no page; more pages returned",
 			fields{
 				Type:        "hydra:PartialCollectionView",
-				baseID:      "/catalog",
+				baseID:      baseID,
 				total:       7012,
 				currentPage: 0,
 			},
 			&HydraView{
 				ID:          "/catalog?page=1",
-				Type:        "hydra:PartialCollectionView",
-				First:       map[string]string{"@id": "/catalog?page=1"},
+				Type:        hydraType,
+				First:       firstPage,
 				Next:        map[string]string{"@id": "/catalog?page=2"},
 				Last:        map[string]string{"@id": "/catalog?page=7"},
-				baseID:      "/catalog",
+				baseID:      baseID,
 				TotalItems:  7012,
 				currentPage: 1,
 			},
@@ -57,18 +61,18 @@ func TestHydraView_setPager(t *testing.T) {
 		{
 			"with page; more pages returned",
 			fields{
-				Type:        "hydra:PartialCollectionView",
-				baseID:      "/catalog",
+				Type:        hydraType,
+				baseID:      baseID,
 				total:       7012,
 				currentPage: 4,
 			},
 			&HydraView{
 				ID:          "/catalog?page=4",
-				Type:        "hydra:PartialCollectionView",
+				Type:        hydraType,
 				First:       map[string]string{"@id": "/catalog?page=1"},
 				Next:        map[string]string{"@id": "/catalog?page=5"},
 				Last:        map[string]string{"@id": "/catalog?page=7"},
-				baseID:      "/catalog",
+				baseID:      baseID,
 				TotalItems:  7012,
 				currentPage: 4,
 			},

--- a/ikuzo/service/x/nde/register.go
+++ b/ikuzo/service/x/nde/register.go
@@ -56,21 +56,21 @@ func (r *RegisterConfig) GetDistributions(spec, datasetType string) []Distributi
 			continue
 		}
 
-		contentUrl := cfg.DownloadFmt
+		contentURL := cfg.DownloadFmt
 		fmtCnt := strings.Count(cfg.DownloadFmt, "%s")
 
 		if fmtCnt > 0 {
 			switch fmtCnt {
 			case 1:
-				contentUrl = fmt.Sprintf(cfg.DownloadFmt, spec)
+				contentURL = fmt.Sprintf(cfg.DownloadFmt, spec)
 			case 2:
-				contentUrl = fmt.Sprintf(cfg.DownloadFmt, r.Publisher.URL, spec)
+				contentURL = fmt.Sprintf(cfg.DownloadFmt, r.Publisher.URL, spec)
 			}
 		}
 
 		distributions = append(distributions, Distribution{
 			Type:           "DataDownload",
-			ContentURL:     contentUrl,
+			ContentURL:     contentURL,
 			EncodingFormat: cfg.MimeType,
 		})
 	}
@@ -80,9 +80,12 @@ func (r *RegisterConfig) GetDistributions(spec, datasetType string) []Distributi
 
 func (r *RegisterConfig) newCatalog() *Catalog {
 	c := &Catalog{
-		Context:     "https://schema.org/",
+		Context: []any{
+			"https://schema.org/",
+			map[string]string{"hydra": "http://www.w3.org/ns/hydra/core#"},
+		},
+		Type:        []string{"DataCatalog", "hydra:Collection"},
 		ID:          fmt.Sprintf("%s/id/datacatalog", r.RDFBaseURL),
-		Type:        "DataCatalog",
 		Dataset:     []*Dataset{},
 		Description: r.Description,
 		Name:        r.Name,

--- a/ikuzo/service/x/nde/routes.go
+++ b/ikuzo/service/x/nde/routes.go
@@ -26,6 +26,9 @@ func (s *Service) lodRedirect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	newPath := strings.Replace(r.URL.Path, "/id/", "/doc/", 1)
+	if r.URL.RawQuery != "" {
+		newPath = newPath + "?" + r.URL.RawQuery
+	}
 	http.Redirect(w, r, newPath, http.StatusFound)
 }
 

--- a/ikuzo/service/x/nde/service.go
+++ b/ikuzo/service/x/nde/service.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/go-chi/chi"
+
 	"github.com/delving/hub3/hub3/ead"
 	"github.com/delving/hub3/ikuzo/domain"
-	"github.com/go-chi/chi"
 )
 
 type Option func(*Service) error
@@ -99,6 +100,17 @@ func (s *Service) HandleCatalog(w http.ResponseWriter, r *http.Request) {
 	}
 
 	catalog := cfg.newCatalog()
+
+	total, err := s.getDatasetsCount(orgID.String(), cfg.RecordTypeFilter)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := catalog.addHydraView(r.URL.Query().Get("page"), total); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	if err := s.AddDatasets(orgID.String(), catalog, cfg.RecordTypeFilter); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
The datacatalogs now support pagination with a max of 1000 datasets per page, see https://netwerk-digitaal-erfgoed.github.io/requirements-datasets/#pagination. 