### PR TITLE
Graph serialization error in oai-pmh store

### DIFF
--- a/ikuzo/driver/elasticsearch/oaipmh_store_test.go
+++ b/ikuzo/driver/elasticsearch/oaipmh_store_test.go
@@ -1,0 +1,28 @@
+package elasticsearch
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func ParseFragmentGraph(t *testing.T) {
+	is := is.New(t)
+
+	f, err := os.ReadFile("./testdata/sample_graph.json")
+	is.NoErr(err)
+
+	fg, err := decodeFragmentGraph(json.RawMessage(f))
+	is.NoErr(err)
+	_ = fg
+
+	store := OAIPMHStore{}
+	var buf bytes.Buffer
+	serializeErr := store.serialize("rdf-xml", fg, &buf)
+	is.NoErr(serializeErr)
+
+	is.True(buf.Len() > 0)
+}


### PR DESCRIPTION
In some case the OAI-PMH store for elasticsearch gives back a serialization error. This should not occur. This pull request tries to identify the issue and remedy it.

feat(elasticsearch): add test for OAIPMHStore.serialize() method to ensure it returns a non-empty buffer