### PR TITLE
Fix/nde register main routing

### DIFF
--- a/ikuzo/driver/elasticsearch/oaipmh_store_test.go
+++ b/ikuzo/driver/elasticsearch/oaipmh_store_test.go
@@ -1,0 +1,28 @@
+package elasticsearch
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func ParseFragmentGraph(t *testing.T) {
+	is := is.New(t)
+
+	f, err := os.ReadFile("./testdata/sample_graph.json")
+	is.NoErr(err)
+
+	fg, err := decodeFragmentGraph(json.RawMessage(f))
+	is.NoErr(err)
+	_ = fg
+
+	store := OAIPMHStore{}
+	var buf bytes.Buffer
+	serializeErr := store.serialize("rdf-xml", fg, &buf)
+	is.NoErr(serializeErr)
+
+	is.True(buf.Len() > 0)
+}

--- a/ikuzo/service/x/nde/register.go
+++ b/ikuzo/service/x/nde/register.go
@@ -85,7 +85,7 @@ func (r *RegisterConfig) newCatalog() *Catalog {
 			map[string]string{"hydra": "http://www.w3.org/ns/hydra/core#"},
 		},
 		Type:        []string{"DataCatalog", "hydra:Collection"},
-		ID:          fmt.Sprintf("%s/id/datacatalog", r.RDFBaseURL),
+		ID:          fmt.Sprintf("%s/id/datacatalog/%s", r.RDFBaseURL, r.URLPrefix),
 		Dataset:     []*Dataset{},
 		Description: r.Description,
 		Name:        r.Name,


### PR DESCRIPTION
Make sure that the main @id of an register object is aware of the URL prefix. Otherwise the resulting RDF is inconsistent