### PR TITLE
Fix empty literal serialization error

### DIFF
--- a/hub3/fragments/resource.go
+++ b/hub3/fragments/resource.go
@@ -25,15 +25,16 @@ import (
 	"time"
 	"unicode"
 
+	r "github.com/kiivihal/rdf2go"
+	elastic "github.com/olivere/elastic/v7"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+
 	c "github.com/delving/hub3/config"
 	"github.com/delving/hub3/hub3/index"
 	"github.com/delving/hub3/ikuzo/rdf"
 	"github.com/delving/hub3/ikuzo/search"
 	"github.com/delving/hub3/ikuzo/storage/x/memory"
-	r "github.com/kiivihal/rdf2go"
-	elastic "github.com/olivere/elastic/v7"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -1113,9 +1114,9 @@ func (re *ResourceEntry) AsTriple(subject rdf.Subject) (*rdf.Triple, error) {
 		case re.Language != "":
 			object, err = rdf.NewLiteralWithLang(re.Value, re.Language)
 		case re.DataType != "":
-			dt, err := rdf.NewIRI(re.DataType)
-			if err != nil {
-				return nil, err
+			dt, iriErr := rdf.NewIRI(re.DataType)
+			if iriErr != nil {
+				return nil, iriErr
 			}
 			object, err = rdf.NewLiteralWithType(re.Value, dt)
 		default:
@@ -1123,6 +1124,7 @@ func (re *ResourceEntry) AsTriple(subject rdf.Subject) (*rdf.Triple, error) {
 		}
 	default:
 		log.Printf("bad datatype: '%#v'", re)
+		return nil, fmt.Errorf("unknown RDF datatype; '%#v'", re.EntryType)
 	}
 
 	if err != nil {

--- a/hub3/fragments/resource.go
+++ b/hub3/fragments/resource.go
@@ -1106,6 +1106,9 @@ func (re *ResourceEntry) AsTriple(subject rdf.Subject) (*rdf.Triple, error) {
 	case resourceType:
 		object, err = rdf.NewIRI(re.ID)
 	case literal:
+		if strings.TrimSpace(re.Value) == "" {
+			return nil, fmt.Errorf("empty object literal is not allowed: %s -> %s", re.ID, re.Predicate)
+		}
 		switch {
 		case re.Language != "":
 			object, err = rdf.NewLiteralWithLang(re.Value, re.Language)

--- a/ikuzo/driver/elasticsearch/oaipmh_store_test.go
+++ b/ikuzo/driver/elasticsearch/oaipmh_store_test.go
@@ -1,8 +1,6 @@
 package elasticsearch
 
 import (
-	"bytes"
-	"encoding/json"
 	"os"
 	"testing"
 
@@ -15,14 +13,15 @@ func ParseFragmentGraph(t *testing.T) {
 	f, err := os.ReadFile("./testdata/sample_graph.json")
 	is.NoErr(err)
 
-	fg, err := decodeFragmentGraph(json.RawMessage(f))
-	is.NoErr(err)
-	_ = fg
-
 	store := OAIPMHStore{}
-	var buf bytes.Buffer
-	serializeErr := store.serialize("rdf-xml", fg, &buf)
-	is.NoErr(serializeErr)
 
-	is.True(buf.Len() > 0)
+	record, err := store.getOAIPMHRecord(recordWrapper{
+		HubID: "123",
+		Data:  f,
+	},
+		"oai_dc",
+		false)
+
+	is.NoErr(err)
+	is.True(len(record.Metadata.Body) > 0)
 }

--- a/ikuzo/driver/elasticsearch/testdata/sample_graph.json
+++ b/ikuzo/driver/elasticsearch/testdata/sample_graph.json
@@ -1,0 +1,318 @@
+{
+  "meta": {
+    "orgID": "NL-HaNA",
+    "spec": "2-24-01-04ntfoto",
+    "revision": 24,
+    "hubID": "NL-HaNA_2-24-01-04ntfoto_a9280850-d0b4-102d-bcf8-003048976d84",
+    "tags": [
+      "narthex",
+      "mdr",
+      "oaipmh"
+    ],
+    "docType": "graph",
+    "entryURI": "https://archief.nl/doc/fotorecord/a9280850-d0b4-102d-bcf8-003048976d84",
+    "namedGraphURI": "https://archief.nl/doc/fotorecord/a9280850-d0b4-102d-bcf8-003048976d84/graph",
+    "modified": 1688479622713
+  },
+  "jsonld": [
+    {
+      "@id": "https://archief.nl/doc/fotorecord/a9280850-d0b4-102d-bcf8-003048976d84",
+      "@type": [
+        "https://archief.nl/def/ontologie/Recordaggregatie"
+      ],
+      "http://purl.org/dc/elements/1.1/identifier": [
+        {
+          "@value": "a9280850-d0b4-102d-bcf8-003048976d84"
+        }
+      ],
+      "http://purl.org/dc/terms/creator": [
+        {
+          "@id": "https://archief.nl/id/vervaardiger/duinen__van__anefo"
+        }
+      ],
+      "http://www.europeana.eu/schemas/edm/hasView": [
+        {
+          "@id": "https://service.archief.nl/gaf/api/file/v1/thumb/a70340ee-d986-44f9-bc56-3284ace96fa6"
+        }
+      ],
+      "http://www.europeana.eu/schemas/edm/isShownAt": [
+        {
+          "@id": "http://hdl.handle.net/10648/a9280850-d0b4-102d-bcf8-003048976d84"
+        }
+      ],
+      "http://www.europeana.eu/schemas/edm/isShownBy": [
+        {
+          "@id": "https://service.archief.nl/gaf/api/file/v1/default/a70340ee-d986-44f9-bc56-3284ace96fa6"
+        }
+      ],
+      "http://www.openarchives.org/ore/terms/aggregates": [
+        {
+          "@id": "https://archief.nl/id/beschrijving/a9280850-d0b4-102d-bcf8-003048976d84"
+        },
+        {
+          "@id": "https://archief.nl/id/foto/a9280850-d0b4-102d-bcf8-003048976d84"
+        }
+      ],
+      "http://www.openarchives.org/ore/terms/isAggregatedBy": [
+        {
+          "@id": "https://archief.nl/doc/2.24.01.04ntfoto"
+        }
+      ],
+      "http://www.w3.org/2000/01/rdf-schema#label": [
+        {
+          "@value": "Record over foto"
+        }
+      ],
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@value": "Record over foto"
+        }
+      ],
+      "https://archief.nl/def/ontologie/isAggregatietype": [
+        {
+          "@id": "https://archief.nl/def/FotoRecord"
+        }
+      ]
+    },
+    {
+      "@id": "https://archief.nl/id/beschrijving/a9280850-d0b4-102d-bcf8-003048976d84",
+      "@type": [
+        "https://archief.nl/def/ontologie/Archiefbeschrijving"
+      ],
+      "http://purl.org/dc/elements/1.1/description": [
+        {
+          "@value": "Nederlandse tenniskampioenschappen op de METS-banen te Scheveningen. Dames dubbel kwartfinale. Vlnr. Jopie Roos-van der Wal, Truid Blaisse-Terwindt tegen Bokhorst en Berna Thung"
+        }
+      ],
+      "http://purl.org/dc/terms/date": [
+        {
+          "@value": "1954-08-20"
+        }
+      ],
+      "http://purl.org/dc/terms/subject": [
+        {
+          "@id": "http://data.beeldengeluid.nl/gtaa/45285"
+        },
+        {
+          "@id": "http://data.beeldengeluid.nl/gtaa/42198"
+        }
+      ],
+      "http://www.w3.org/2000/01/rdf-schema#label": [
+        {
+          "@value": "Beschrijving van a9280850-d0b4-102d-bcf8-003048976d84"
+        }
+      ],
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@value": "Beschrijving van a9280850-d0b4-102d-bcf8-003048976d84"
+        }
+      ],
+      "http://www.w3.org/ns/odrl/2/hasPolicy": [
+        {
+          "@id": "https://archief.nl/def/Policy/set_b_rechtenvrij__publiek_domein"
+        }
+      ],
+      "http://xmlns.com/foaf/0.1/primaryTopic": [
+        {
+          "@id": "https://archief.nl/id/foto/a9280850-d0b4-102d-bcf8-003048976d84"
+        }
+      ],
+      "https://archief.nl/def/ontologie/titelFotocollectie": [
+        {
+          "@value": "Fotocollectie Anefo"
+        }
+      ],
+      "https://archief.nl/def/ontologie/toelichting": [
+        {
+          "@value": "",
+          "@language": "nl"
+        }
+      ],
+      "https://archief.nl/def/ontologie/trefwoordAlgemeen": [
+        {
+          "@value": "tenniskampioenschappen"
+        }
+      ],
+      "https://archief.nl/def/ontologie/trefwoordLocatie": [
+        {
+          "@value": "Zuid-Holland"
+        },
+        {
+          "@value": "Scheveningen"
+        }
+      ]
+    },
+    {
+      "@id": "https://archief.nl/id/foto/a9280850-d0b4-102d-bcf8-003048976d84",
+      "@type": [
+        "https://archief.nl/def/ontologie/Archiefeenheid",
+        "http://www.w3.org/ns/odrl/2/Asset"
+      ],
+      "http://purl.org/dc/elements/1.1/format": [
+        {
+          "@value": "4 x 5 inch"
+        }
+      ],
+      "http://www.w3.org/2000/01/rdf-schema#label": [
+        {
+          "@value": "Archiefeenheid met identifier: a9280850-d0b4-102d-bcf8-003048976d84"
+        }
+      ],
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@value": "Archiefeenheid met identifier: a9280850-d0b4-102d-bcf8-003048976d84"
+        }
+      ],
+      "https://archief.nl/def/ontologie/archiefLink": [
+        {
+          "@value": "NL-HaNA_2.24.01.04_0_906-6720"
+        }
+      ],
+      "https://archief.nl/def/ontologie/bestanddeelnummer": [
+        {
+          "@value": "906-6720"
+        }
+      ],
+      "https://archief.nl/def/ontologie/isArchiefeenheidtype": [
+        {
+          "@id": "https://archief.nl/def/Foto"
+        }
+      ],
+      "https://archief.nl/def/ontologie/isMateriaaltype": [
+        {
+          "@value": "Negatief (zwart/wit)"
+        }
+      ],
+      "https://archief.nl/def/ontologie/toegangsnummer": [
+        {
+          "@value": "2.24.01.04"
+        }
+      ]
+    },
+    {
+      "@id": "https://service.archief.nl/gaf/api/file/v1/thumb/a70340ee-d986-44f9-bc56-3284ace96fa6",
+      "@type": [
+        "http://www.europeana.eu/schemas/edm/WebResource"
+      ],
+      "http://www.w3.org/2000/01/rdf-schema#label": [
+        {
+          "@value": "Foto met fileUUID: a70340ee-d986-44f9-bc56-3284ace96fa6"
+        }
+      ],
+      "https://archief.nl/def/ontologie/download": [
+        {
+          "@value": "Direct beschikbaar"
+        }
+      ],
+      "https://archief.nl/def/ontologie/du-uuid": [
+        {
+          "@value": "e035da5a-7480-45d5-b512-67ff11be75f9"
+        }
+      ],
+      "https://archief.nl/def/ontologie/file-uuid": [
+        {
+          "@value": "a70340ee-d986-44f9-bc56-3284ace96fa6"
+        }
+      ],
+      "https://archief.nl/def/ontologie/handle-uuid": [
+        {
+          "@value": "a9280850-d0b4-102d-bcf8-003048976d84"
+        }
+      ],
+      "https://archief.nl/def/ontologie/volgnummer": [
+        {
+          "@value": "1"
+        }
+      ],
+      "https://archief.nl/def/ontologie/webserviceDefault": [
+        {
+          "@id": "https://service.archief.nl/gaf/api/file/v1/default/a70340ee-d986-44f9-bc56-3284ace96fa6"
+        }
+      ],
+      "https://archief.nl/def/ontologie/webserviceIIIF": [
+        {
+          "@id": "https://service.archief.nl/iip/e0/35/da/5a/74/80/45/d5/b5/12/67/ff/11/be/75/f9/a70340ee-d986-44f9-bc56-3284ace96fa6.jp2/info.json"
+        }
+      ],
+      "https://archief.nl/def/ontologie/webserviceIcon": [
+        {
+          "@id": "https://service.archief.nl/gaf/api/file/v1/icon/a70340ee-d986-44f9-bc56-3284ace96fa6"
+        }
+      ],
+      "https://archief.nl/def/ontologie/webserviceImage": [
+        {
+          "@id": "https://service.archief.nl/gaf/api/file/v1/original/a70340ee-d986-44f9-bc56-3284ace96fa6"
+        }
+      ],
+      "https://archief.nl/def/ontologie/webserviceOriginal": [
+        {
+          "@id": "https://service.archief.nl/gaf/api/file/v1/original/a70340ee-d986-44f9-bc56-3284ace96fa6"
+        }
+      ],
+      "https://archief.nl/def/ontologie/webserviceThumbnail": [
+        {
+          "@id": "https://service.archief.nl/gaf/api/file/v1/thumb/a70340ee-d986-44f9-bc56-3284ace96fa6"
+        }
+      ]
+    },
+    {
+      "@id": "https://archief.nl/def/Policy/set_b_rechtenvrij__publiek_domein",
+      "@type": [
+        "http://www.w3.org/ns/odrl/2/Policy"
+      ],
+      "http://purl.org/dc/terms/rightsHolder": [
+        {
+          "@value": "Nationaal Archief, CC0"
+        }
+      ],
+      "http://www.w3.org/2000/01/rdf-schema#label": [
+        {
+          "@value": "Set B: Rechtenvrij / Publiek Domein"
+        }
+      ],
+      "http://www.w3.org/ns/odrl/2/permission": [
+        {
+          "@value": "Set B: Rechtenvrij / Publiek Domein"
+        }
+      ]
+    },
+    {
+      "@id": "http://data.beeldengeluid.nl/gtaa/45285",
+      "@type": [
+        "http://www.w3.org/2004/02/skos/core#Concept"
+      ],
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@value": "Zuid-Holland"
+        }
+      ]
+    },
+    {
+      "@id": "https://archief.nl/id/vervaardiger/duinen__van__anefo",
+      "@type": [
+        "https://archief.nl/def/ontologie/Agent"
+      ],
+      "http://www.w3.org/2000/01/rdf-schema#label": [
+        {
+          "@value": "Duinen, […] van / Anefo (vervaardiger)"
+        }
+      ],
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@value": "Duinen, […] van / Anefo"
+        }
+      ]
+    },
+    {
+      "@id": "http://data.beeldengeluid.nl/gtaa/42198",
+      "@type": [
+        "http://www.w3.org/2004/02/skos/core#Concept"
+      ],
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@value": "Scheveningen"
+        }
+      ]
+    }
+  ]
+}

--- a/ikuzo/rdf/formats/mappingxml/serializer.go
+++ b/ikuzo/rdf/formats/mappingxml/serializer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/beevik/etree"
+
 	"github.com/delving/hub3/ikuzo/rdf"
 )
 


### PR DESCRIPTION
In some case when parsing JSON-LD objects with a language tag but no content were allowed into the graph. This caused some unexpected and difficult to catch errors downstream when serializing the graph. This fix catches the errors earlier during the json-ld parsing and gives better error messages when this error is encountered.