### PR TITLE
Update README.md – fixed links for further docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Start the server with the default configuration.
 
     $ hub3 http
 
-For development setup, see [Develop](./docs/development.md).
+For development setup, see [Develop](./docs/hub3/development.md).
 
-For deployment instructions, see [Deployment](./docs/deployment.md).
+For deployment instructions, see [Deployment](./docs/hub3/deployment.md).
 
 ## Changelog
 


### PR DESCRIPTION
Docs for development en deployment were put in a subfolder. link to those files was not corrected in readme.md