### PR TITLE
fix(nde): also show next on page before last

### DIFF
--- a/ikuzo/service/x/nde/dataset.go
+++ b/ikuzo/service/x/nde/dataset.go
@@ -118,7 +118,7 @@ func (hv *HydraView) setPager() {
 	hv.First = map[string]string{"@id": hv.hydraPage(1)}
 	next := hv.currentPage + 1
 	totalPages := int(hv.TotalItems / hydraObjectPerPage)
-	if next < totalPages {
+	if next <= totalPages {
 		hv.Next = map[string]string{"@id": hv.hydraPage(next)}
 	}
 	if totalPages > 1 {

--- a/ikuzo/service/x/nde/dataset_test.go
+++ b/ikuzo/service/x/nde/dataset_test.go
@@ -77,6 +77,25 @@ func TestHydraView_setPager(t *testing.T) {
 				currentPage: 4,
 			},
 		},
+		{
+			"with page; before last returned",
+			fields{
+				Type:        hydraType,
+				baseID:      baseID,
+				total:       7012,
+				currentPage: 13,
+			},
+			&HydraView{
+				ID:          "/catalog?page=13",
+				Type:        hydraType,
+				First:       map[string]string{"@id": "/catalog?page=1"},
+				Next:        map[string]string{"@id": "/catalog?page=14"},
+				Last:        map[string]string{"@id": "/catalog?page=14"},
+				baseID:      baseID,
+				TotalItems:  7012,
+				currentPage: 13,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
On previous to last page, the hydra pager for the nde dataset should also show the next page.