### PR TITLE
fix(search): skip MLT for orgs without a legacy V1 config instead of panicking

### DIFF
--- a/hub3/server/http/handlers/search.go
+++ b/hub3/server/http/handlers/search.go
@@ -1463,7 +1463,10 @@ func getSearchRecord(w http.ResponseWriter, r *http.Request) {
 
 		if mltEnabled {
 			conv, convErr := legacy.DefaultConverter(record.Meta.EntryURI, record.Meta.OrgID)
-			if convErr == nil {
+			// Configuration() is nil for orgs without a registered legacy V1
+			// config (DefaultConverter still returns a fallback converter for
+			// them); skip MLT instead of dereferencing a nil config.
+			if convErr == nil && conv.Configuration() != nil {
 				cfg := conv.Configuration()
 				mltCount := parseMltCount(r.URL.Query(), cfg.MLT.DefaultCount)
 				var mltFilterKeys []string


### PR DESCRIPTION
## What

`getSearchRecord` dereferenced `conv.Configuration()` unguarded when handling `moreLikeThis=true`. For orgs absent from the legacy V1 converter registry, `legacy.DefaultConverter` returns a fallback converter whose `Configuration()` is nil — so any record request with MLT enabled panicked into a 500.

## Impact

Every DIW sends `moreLikeThis=true` on item detail views when related items are enabled, and the panic kills the whole record request, not just the MLT block. Production orgs all have V1 configs so this never fired there — but any new org onboarded without a legacy config block (as happened with the `orchestra` dev org, found 2026-07-13 during WP deep-link QA) breaks on its first item view.

## Fix

Guard the dereference: skip the MLT block when `Configuration()` is nil. The record itself is served normally, just without related items.

Cherry-pick of 2a85addf from orc/api-ui-v1, taken independently of that branch per the merge hold. Compile-checked against the current dev-v0.5 tip.

Generated with [Claude Code](https://claude.com/claude-code)