### PR TITLE
Sitemap UseHubID mode: DIW deep-link locs + IndexBaseURL for sub-sitemap hosts

### DIFF
--- a/ikuzo/domain/organization_config.go
+++ b/ikuzo/domain/organization_config.go
@@ -54,6 +54,14 @@ type SitemapConfig struct {
 	DataPath      string   `json:"dataPath,omitempty"`
 	RelPathFmt    string   `json:"relPathFmt,omitempty"`
 	ContextIndex  string   `json:"contextIndex,omitempty"`
+	// UseHubID formats the record's full hubID into RelPathFmt
+	// (query-escaped) instead of the last path segment of its EntryURI.
+	// Used for DIW deep links of the form ?id=<hubID>.
+	UseHubID bool `json:"useHubID,omitempty"`
+	// IndexBaseURL overrides the host used for sub-sitemap locations in
+	// the sitemap index. Set it when BaseURL points at the customer site
+	// while the sitemap files themselves are served from this hub3 host.
+	IndexBaseURL string `json:"indexBaseURL,omitempty"`
 }
 
 func (cfg *SitemapConfig) IsExcludedSpec(spec string) bool {
@@ -70,13 +78,31 @@ func (cfg *SitemapConfig) Path(spec string, page int) string {
 	return filepath.Join(cfg.DataPath, cfg.OrgID, spec, fmt.Sprint(page)+".xml")
 }
 
+// URL renders the public location for a record id according to RelPathFmt.
+// In UseHubID mode the full id is query-escaped into the format verb; in
+// legacy mode only the last path segment of the id is used.
 func (cfg *SitemapConfig) URL(id string) string {
 	if cfg.RelPathFmt == "" {
 		return id
 	}
+
+	if cfg.UseHubID {
+		return fmt.Sprintf("%s%s", cfg.BaseURL, fmt.Sprintf(cfg.RelPathFmt, url.QueryEscape(id)))
+	}
+
 	parts := strings.Split(id, "/")
 	path := fmt.Sprintf(cfg.RelPathFmt, parts[len(parts)-1])
 	return fmt.Sprintf("%s%s", cfg.BaseURL, path)
+}
+
+// IndexBase returns the base URL for sub-sitemap locations in the sitemap
+// index: IndexBaseURL when set, otherwise BaseURL.
+func (cfg *SitemapConfig) IndexBase() string {
+	if cfg.IndexBaseURL != "" {
+		return cfg.IndexBaseURL
+	}
+
+	return cfg.BaseURL
 }
 
 type OAIPMHConfig struct {

--- a/ikuzo/domain/organization_config_test.go
+++ b/ikuzo/domain/organization_config_test.go
@@ -1,0 +1,57 @@
+package domain
+
+import "testing"
+
+// TestSitemapConfigURL covers both URL modes: legacy last-path-segment
+// formatting and UseHubID full-id formatting for DIW deep links.
+func TestSitemapConfigURL(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  SitemapConfig
+		id   string
+		want string
+	}{
+		{
+			name: "legacy: last path segment into RelPathFmt",
+			cfg:  SitemapConfig{BaseURL: "https://example.org", RelPathFmt: "/doc/%s"},
+			id:   "https://data.example.org/resource/aggregation/spec/local-1",
+			want: "https://example.org/doc/local-1",
+		},
+		{
+			name: "legacy: empty RelPathFmt returns id verbatim",
+			cfg:  SitemapConfig{BaseURL: "https://example.org"},
+			id:   "https://data.example.org/resource/x",
+			want: "https://data.example.org/resource/x",
+		},
+		{
+			name: "useHubID: full id query-escaped into RelPathFmt",
+			cfg: SitemapConfig{
+				BaseURL:    "https://verhaalvanutrecht.nl/collecties/",
+				RelPathFmt: "?id=%s",
+				UseHubID:   true,
+			},
+			id:   "leu/collection/local-1",
+			want: "https://verhaalvanutrecht.nl/collecties/?id=leu%2Fcollection%2Flocal-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.URL(tt.id); got != tt.want {
+				t.Errorf("URL(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSitemapConfigIndexBase covers the sub-sitemap host override.
+func TestSitemapConfigIndexBase(t *testing.T) {
+	cfg := SitemapConfig{BaseURL: "https://customer.example"}
+	if got := cfg.IndexBase(); got != "https://customer.example" {
+		t.Errorf("IndexBase() = %q, want BaseURL fallback", got)
+	}
+	cfg.IndexBaseURL = "https://hub.example"
+	if got := cfg.IndexBase(); got != "https://hub.example" {
+		t.Errorf("IndexBase() = %q, want IndexBaseURL", got)
+	}
+}

--- a/ikuzo/driver/elasticsearch/sitemap.go
+++ b/ikuzo/driver/elasticsearch/sitemap.go
@@ -131,8 +131,12 @@ func (s *SitemapStore) Locations(ctx context.Context, spec string, cfg domain.Si
 
 		for _, h := range headers {
 			lastMod := h.LastModified()
+			id := h.EntryURI
+			if cfg.UseHubID {
+				id = h.GetHubID()
+			}
 			loc := sitemap.Location{
-				ID:      h.EntryURI,
+				ID:      id,
 				LastMod: &lastMod,
 			}
 			if cbErr := cb(loc); cbErr != nil {

--- a/ikuzo/service/x/sitemap/service.go
+++ b/ikuzo/service/x/sitemap/service.go
@@ -65,7 +65,7 @@ func (s *Service) sitemapRoot(ctx context.Context, cfg domain.SitemapConfig) (*s
 			smi.Add(&sitemap.URL{
 				Loc: fmt.Sprintf(
 					"%s/api/sitemap/%s/%s/%d",
-					cfg.BaseURL,
+					cfg.IndexBase(),
 					cfg.ID,
 					d.ID,
 					page,

--- a/ikuzo/service/x/sitemap/service_test.go
+++ b/ikuzo/service/x/sitemap/service_test.go
@@ -1,9 +1,27 @@
 package sitemap
 
 import (
+	"context"
 	"reflect"
 	"testing"
+
+	"github.com/delving/hub3/ikuzo/domain"
 )
+
+// fakeStore is a minimal Store implementation used to exercise sitemapRoot
+// without a live Elasticsearch backend.
+type fakeStore struct{}
+
+// Datasets returns a single fixed dataset so sitemapRoot has something to
+// build a sub-sitemap location for.
+func (f *fakeStore) Datasets(ctx context.Context, cfg domain.SitemapConfig) ([]Location, error) {
+	return []Location{{ID: "spec-a", RecordCount: 1}}, nil
+}
+
+// Locations is unused by TestSitemapRootIndexBase but required to satisfy Store.
+func (f *fakeStore) Locations(ctx context.Context, spec string, cfg domain.SitemapConfig, cb func(loc Location) error) error {
+	return nil
+}
 
 func Test_getMaxPages(t *testing.T) {
 	type args struct {
@@ -36,5 +54,31 @@ func Test_getMaxPages(t *testing.T) {
 				t.Errorf("getMaxPages() = %v, want %v", gotPages, tt.wantPages)
 			}
 		})
+	}
+}
+
+// TestSitemapRootIndexBase asserts sub-sitemap locations use IndexBaseURL
+// when set, so a customer-site BaseURL never leaks into sitemap-index Locs.
+func TestSitemapRootIndexBase(t *testing.T) {
+	svc, err := NewService(SetStore(&fakeStore{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := domain.SitemapConfig{
+		ID:           "vvu",
+		BaseURL:      "https://verhaalvanutrecht.nl/collecties/",
+		IndexBaseURL: "https://prod.utralt.hubs.delving.org",
+	}
+
+	smi, err := svc.sitemapRoot(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loc := smi.URLs[0].Loc
+	want := "https://prod.utralt.hubs.delving.org/api/sitemap/vvu/spec-a/1"
+	if loc != want {
+		t.Errorf("sitemapRoot Loc = %q, want %q", loc, want)
 	}
 }


### PR DESCRIPTION
Adds a UseHubID mode to the sitemap service: loc URLs become customer-page deep links (baseURL + relPathFmt with the record hubID) instead of LOD resource paths, and IndexBaseURL lets the sub-sitemap files live on the hubs host while locs point at the customer domain.

Mechanics verified locally on 24k records (2026-07-10); WP deep-link round-trip QA passed 2026-07-13; VvU pre-flight (v1 DIW, relPathFmt ?diw-id=) completed 2026-07-22 — see orchestra docs/runbooks/hubs-robots-txt-seo.md.

Generated with [Claude Code](https://claude.com/claude-code)